### PR TITLE
Add Elasticsearch synchronization task

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 PORT=3005
 NO_AUTH=true
 CORS_ORIGINS_ALLOWED=https://opencouncil.gr,http://localhost:3000
-PUBLIC_URL=https://your-ngrok-url.ngrok.io
+PUBLIC_URL="http://localhost:3005"
 
 # Digital Ocean Spaces Configuration
 DO_SPACES_KEY=your-spaces-key
@@ -24,3 +24,8 @@ ADALINE_SECRET=your-adaline-secret
 PYANNOTE_DIARIZE_API_URL="https://api.pyannote.ai/v1"
 PYANNOTE_API_TOKEN=your-pyannote-api-token
 MOCK_PYANNOTE=true
+
+# Data Synchronization
+ELASTICSEARCH_HOST=your-es-host
+ELASTICSEARCH_API_KEY=your-es-api-key
+ELASTICSEARCH_CONNECTOR_ID="opencouncil-postgresql"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The server supports the following processing tasks:
 - [`applyDiarization`](src/tasks/applyDiarization.ts) - Applies speaker identification to existing transcripts
 - [`generateVoiceprint`](src/tasks/generateVoiceprint.ts) - Creates unique speaker voice fingerprints for identification
 
+### Data Synchronization
+- [`syncElasticsearch`](src/tasks/syncElasticsearch.ts) - Triggers and monitors a data synchronization job between PostgreSQL and Elasticsearch.
+
 The [`pipeline`](src/tasks/pipeline.ts) task orchestrates multiple tasks above in sequence, providing a complete end-to-end processing workflow.
 
 ## 🛠️ Development Setup
@@ -47,13 +50,42 @@ cp .env.example .env
 
 Then edit the file to include your specific [configuration values](#configuration).
 
+
 ### Docker Setup (Recommended)
 
-The Docker setup includes both the main service and the Cobalt API service for YouTube video processing. The services are automatically configured to work together through Docker's internal network.
+The Docker setup includes the main service, the Cobalt API service for YouTube video processing, and the Elastic connector for data synchronization.
+
+#### Standalone Mode
+
+If you are running this service by itself without needing to connect to the main OpenCouncil application, you can start it with the standard command:
 
 ```bash
+# This runs the app service and its dependencies
 docker compose up app
 ```
+
+#### Integrated Development Mode
+
+This mode is for when you are developing locally and need this service to communicate with the main `opencouncil` application.
+
+**Prerequisite**
+
+Before starting in this mode, you must first start the main `opencouncil` project using its `./run.sh` script. This step is essential because it creates the shared Docker network named `opencouncil-net` that this project will connect to.
+
+**Command**
+
+Once the `opencouncil` project is running, start this tasks service with the following command:
+
+```bash
+# Use this for local development alongside the main opencouncil project
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up app
+```
+
+**How it Works**
+
+This command uses the `docker-compose.dev.yml` file, which tells Docker to connect this project's services to the `external` network named `opencouncil-net`.
+
+This allows the two projects to communicate directly and efficiently within Docker.
 
 ### Manual Setup
 ```bash
@@ -127,6 +159,9 @@ The service uses environment variables for configuration. Not all variables are 
 - `PYANNOTE_API_TOKEN` - Required for speaker diarization
 - `PYANNOTE_DIARIZE_API_URL` - Pyannote API endpoint
 - `MOCK_PYANNOTE` - Enable mock mode for Pyannote (development only)
+- `ELASTICSEARCH_HOST` - Elasticsearch host URL
+- `ELASTICSEARCH_API_KEY` - Elasticsearch API key for the connector
+- `ELASTICSEARCH_CONNECTOR_ID` - The ID of the Elasticsearch connector
 
 ### Task-Specific Configuration
 - `GLADIA_MAX_CONCURRENT_TRANSCRIPTIONS` (default: 20) - Maximum concurrent transcription tasks

--- a/connectors-config/config.yml
+++ b/connectors-config/config.yml
@@ -1,0 +1,9 @@
+# This file is used to configure the elasticsearch connector for the opencouncil project.
+# It is used to connect to the elasticsearch instance and ingest the data into the elasticsearch index.
+elasticsearch:
+  host: ${ELASTICSEARCH_HOST}
+  api_key: ${ELASTICSEARCH_API_KEY}
+
+connectors:
+  - connector_id: ${ELASTICSEARCH_CONNECTOR_ID}
+    service_type: "postgresql" 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,11 @@
+services:
+  app:
+    networks:
+      - opencouncil-net
+  cobalt-api:
+    networks:
+      - opencouncil-net
+
+networks:
+  opencouncil-net:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     restart: unless-stopped
     depends_on:
       - cobalt-api
+      - elastic-connector
+
   cobalt-api:
     image: ghcr.io/imputnet/cobalt:10
     restart: unless-stopped
@@ -30,6 +32,18 @@ services:
         - com.centurylinklabs.watchtower.scope=cobalt
     volumes:
       - ./secrets:/secrets
+
+  elastic-connector:
+    image: docker.elastic.co/integrations/elastic-connectors:9.0.0
+    volumes:
+      - ./connectors-config:/config
+    environment:
+      - ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST}
+      - ELASTICSEARCH_API_KEY=${ELASTICSEARCH_API_KEY}
+      - ELASTICSEARCH_CONNECTOR_ID=${ELASTICSEARCH_CONNECTOR_ID}
+    env_file:
+      - .env
+    command: /app/bin/elastic-ingest -c /config/config.yml
 
 x-buildkit:
   enabled: true

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { splitMediaFile } from './tasks/splitMediaFile.js';
 import { fixTranscript } from './tasks/fixTranscript.js';
 import { processAgenda } from './tasks/processAgenda.js';
 import { generateVoiceprint } from './tasks/generateVoiceprint.js';
+import { syncElasticsearch } from './tasks/syncElasticsearch.js';
 
 dotenv.config();
 
@@ -77,6 +78,7 @@ app.post('/generatePodcastSpec', taskManager.serveTask(generatePodcastSpec));
 app.post('/fixTranscript', taskManager.serveTask(fixTranscript));
 app.post('/processAgenda', taskManager.serveTask(processAgenda));
 app.post('/generateVoiceprint', taskManager.serveTask(generateVoiceprint));
+app.post('/syncElasticsearch', taskManager.serveTask(syncElasticsearch));
 
 const testVideo = "https://www.youtube.com/watch?v=3ugZUq9nm4Y";
 
@@ -174,6 +176,15 @@ process.on('SIGTERM', async () => {
 const port = process.env.PORT || 3000;
 const server = app.listen(port, () => {
     console.log(`Server running at http://localhost:${port}`);
+
+    console.log('\nAvailable Endpoints:');
+    (app as any)._router.stack.forEach((middleware: any) => {
+        if (middleware.route) { // routes registered directly on the app
+            const methods = Object.keys(middleware.route.methods).map(method => method.toUpperCase()).join(', ');
+            console.log(`  ${methods.padEnd(8)} ${middleware.route.path}`);
+        }
+    });
+    console.log();
 });
 
 if (process.argv.includes('--console')) {

--- a/src/tasks/syncElasticsearch.ts
+++ b/src/tasks/syncElasticsearch.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import { Task } from './pipeline.js';
+import { SyncElasticsearchRequest, SyncElasticsearchResult } from '../types.js';
+
+const ELASTICSEARCH_HOST = process.env.ELASTICSEARCH_HOST;
+const ELASTICSEARCH_API_KEY = process.env.ELASTICSEARCH_API_KEY;
+const ELASTICSEARCH_CONNECTOR_ID = process.env.ELASTICSEARCH_CONNECTOR_ID;
+
+const POLL_INTERVAL_MS = 10000; // 10 seconds
+const MAX_POLLING_ATTEMPTS = 90; // 15 minutes (90 attempts * 10 seconds)
+const MAX_PENDING_ATTEMPTS = 12; // 2 minutes (12 attempts * 10 seconds)
+
+// Progress reporting constants
+const PROGRESS_STARTING = 10;
+const PROGRESS_JOB_STARTED = 25;
+const PROGRESS_COMPLETED = 100;
+const PROGRESS_INCREMENT_MAX = 70;
+
+const SyncElasticsearchPayload = z.object({
+  job_type: z.enum(['full', 'incremental', 'access_control']).default('full'),
+  trigger_method: z.enum(['on_demand', 'scheduled']).optional(),
+});
+
+const makeRequest = async (path: string, options: RequestInit = {}) => {
+  if (!ELASTICSEARCH_HOST || !ELASTICSEARCH_API_KEY || !ELASTICSEARCH_CONNECTOR_ID) {
+    throw new Error('ELASTICSEARCH_HOST, ELASTICSEARCH_API_KEY and ELASTICSEARCH_CONNECTOR_ID must be set');
+  }
+
+  const url = `${ELASTICSEARCH_HOST}${path}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `ApiKey ${ELASTICSEARCH_API_KEY}`,
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    console.error(`Elasticsearch API error: ${response.status} ${response.statusText} - ${errorBody}`);
+    throw new Error(`Elasticsearch API error: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+};
+
+const startSyncJob = async (job_type: 'full' | 'incremental' | 'access_control', trigger_method?: 'on_demand' | 'scheduled'): Promise<{ id: string }> => {
+    console.log(`Starting new sync job of type: ${job_type}`);
+    return makeRequest('/_connector/_sync_job', {
+      method: 'POST',
+      body: JSON.stringify({
+        id: ELASTICSEARCH_CONNECTOR_ID,
+        job_type,
+        trigger_method,
+      }),
+    });
+  };
+
+const getSyncJobStatus = async (jobId: string): Promise<SyncElasticsearchResult> => {
+    const rawResponse = await makeRequest(`/_connector/_sync_job/${jobId}`);
+    // the full response contains fields with sensitive data, so we need to filter them out
+    const filteredResponse: SyncElasticsearchResult = {
+      id: rawResponse.id,
+      status: rawResponse.status,
+      job_type: rawResponse.job_type,
+      trigger_method: rawResponse.trigger_method,
+      error: rawResponse.error,
+      created_at: rawResponse.created_at,
+      started_at: rawResponse.started_at,
+      last_seen: rawResponse.last_seen,
+      completed_at: rawResponse.completed_at,
+      total_document_count: rawResponse.total_document_count,
+      indexed_document_count: rawResponse.indexed_document_count,
+      deleted_document_count: rawResponse.deleted_document_count,
+    };
+    return filteredResponse;
+};
+
+export const syncElasticsearch: Task<SyncElasticsearchRequest, SyncElasticsearchResult> = async (payload, onProgress) => {
+    const { job_type, trigger_method } = SyncElasticsearchPayload.parse(payload);
+    onProgress('starting', PROGRESS_STARTING);
+
+    const syncJob = await startSyncJob(job_type, trigger_method);
+    onProgress(`Job ${syncJob.id} started`, PROGRESS_JOB_STARTED);
+
+    // Immediately check the status of the job
+    let job = await getSyncJobStatus(syncJob.id);
+    if (job.status === 'error') {
+      throw new Error(`Sync job failed immediately with error: ${job.error}`);
+    }
+
+    let attempts = 0;
+    let pendingAttempts = 0;
+
+    do {
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+      job = await getSyncJobStatus(syncJob.id);
+
+      if (job.status === 'pending') {
+        pendingAttempts++;
+        if (pendingAttempts >= MAX_PENDING_ATTEMPTS) {
+          throw new Error('Sync job has been pending for too long. The connector might be down.');
+        }
+      } else {
+        pendingAttempts = 0;
+      }
+      
+      const progress = PROGRESS_JOB_STARTED + Math.round((attempts / MAX_POLLING_ATTEMPTS) * PROGRESS_INCREMENT_MAX);
+      onProgress(`Job status: ${job.status}`, progress);
+
+      attempts++;
+    } while (['pending', 'in_progress'].includes(job.status) && attempts < MAX_POLLING_ATTEMPTS);
+
+    if (job.status === 'completed') {
+        onProgress('completed', PROGRESS_COMPLETED);
+        return job;
+    } else if (job.status === 'error') {
+        throw new Error(`Sync job failed with error: ${job.error}`);
+    } else if (attempts >= MAX_POLLING_ATTEMPTS) {
+        throw new Error('Sync job timed out.');
+    } else {
+        throw new Error(`Sync job ended with unexpected status: ${job.status}`);
+    }
+}; 

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,3 +320,27 @@ export interface GenerateVoiceprintResult {
     voiceprint: string; // Voiceprint embedding vector in base64
     duration: number; // Duration of the audio
 }
+
+/*
+ * Task: Sync Elasticsearch
+ */
+
+export interface SyncElasticsearchRequest extends TaskRequest {
+    job_type?: 'full' | 'incremental' | 'access_control';
+    trigger_method?: 'on_demand' | 'scheduled';
+}
+
+export interface SyncElasticsearchResult {
+    id: string;
+    status: 'canceling' | 'canceled' | 'completed' | 'error' | 'in_progress' | 'pending' | 'suspended';
+    job_type: 'full' | 'incremental' | 'access_control';
+    trigger_method?: 'on_demand' | 'scheduled';
+    error?: string;
+    created_at: string | number;
+    started_at?: string | number;
+    last_seen?: string | number;
+    completed_at?: string | number;
+    total_document_count?: number;
+    indexed_document_count?: number;
+    deleted_document_count?: number;
+}


### PR DESCRIPTION
## Description

This PR introduces a new data synchronization feature that enables the OpenCouncil tasks service to trigger and monitor data sync jobs between our PostgreSQL database and Elasticsearch. This is accomplished by integrating an Elastic connector and exposing a new `syncElasticsearch` task via an API endpoint. Related to https://github.com/schemalabz/opencouncil/issues/52/.

Additionally, this update enhances the local development experience by providing a dedicated Docker Compose configuration for running the service alongside the main OpenCouncil application stack, ensuring seamless communication between services.


### Changes Made

*   **New `syncElasticsearch` Task**:
    *   Implemented a new task in `src/tasks/syncElasticsearch.ts` that handles the logic for starting and monitoring Elasticsearch sync jobs.
    *   The task communicates with the Elasticsearch API to trigger jobs, poll for status updates (`pending`, `in_progress`), and handle final states (`completed`, `error`).

*   **API Integration**:
    *   Added a new `POST /syncElasticsearch` endpoint in `src/server.ts` to make the task accessible.
    *   Defined the corresponding request and result types (`SyncElasticsearchRequest`, `SyncElasticsearchResult`) in `src/types.ts`.

*   **Docker & Configuration**:
    *   Added an `elastic-connector` service to `docker-compose.yml`.
    *   Introduced a `docker-compose.dev.yml` for integrated local development, allowing the service to connect to the external `opencouncil-net` network.
    *   Updated `.env.example` with the required environment variables for the Elasticsearch connection (`ELASTICSEARCH_HOST`, `ELASTICSEARCH_API_KEY`, `ELASTICSEARCH_CONNECTOR_ID`).
    *   Added `connectors-config/config.yml` to configure the connector service.

*   **Documentation**:
    *   Updated `README.md` to document the new `syncElasticsearch` task and provide clear instructions for the new standalone vs. integrated Docker development setups.

### Testing

I've tested the integration on our digital ocean instance.