### PR TITLE
feat: initial attendance passthrough and extraction format refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ npm test                              # unit tests (vitest)
 - `PipelineDeps` — all injectable dependencies for the pipeline — defined in `src/tasks/pipeline.ts`
 - `TranscribeRequest` / `TranscribeResult` — pipeline input/output — defined in `src/types.ts`
 
+## Task versioning
+
+Tasks in `src/server.ts` have a `version` field in their `registerTask()` metadata. This version is sent with callbacks and stored on `TaskStatus` in the opencouncil database. Bump it when a task's output shape or semantics change (new fields, changed extraction logic, modified prompts). Don't bump for internal refactors that don't affect the result.
+
 ## External services
 
 - **Pyannote** — speaker diarization (async, posts result to callback URL)

--- a/src/server.ts
+++ b/src/server.ts
@@ -186,7 +186,8 @@ app.post('/generateHighlight', taskManager.registerTask(generateHighlight, {
 
 app.post('/pollDecisions', taskManager.registerTask(pollDecisions, {
   summary: 'Poll and extract decisions from Diavgeia',
-  description: 'Fetch decisions from the Greek Government Transparency portal, match them to meeting subjects, and extract structured data (excerpt, attendance, votes) from matched PDFs'
+  description: 'Fetch decisions from the Greek Government Transparency portal, match them to meeting subjects, and extract structured data (excerpt, attendance, votes) from matched PDFs',
+  version: 1,
 }));
 
 // Resolve task paths from Express routes, then load API Documentation

--- a/src/tasks/pollDecisions.test.ts
+++ b/src/tasks/pollDecisions.test.ts
@@ -27,7 +27,7 @@ vi.mock("../lib/ai.js", () => ({
 
 // Mock extractionPipeline (extraction is tested separately)
 vi.mock("./utils/extractionPipeline.js", () => ({
-    extractDecisionsFromPdfs: vi.fn(async () => ({ decisions: [], warnings: [], usage: NO_USAGE_MOCK })),
+    extractDecisionsFromPdfs: vi.fn(async () => ({ decisions: [], warnings: [], usage: NO_USAGE_MOCK, initialAttendance: [], unmatchedInitialAttendance: [] })),
 }));
 
 import { aiChat } from "../lib/ai.js";
@@ -399,6 +399,8 @@ describe("pollDecisions - verification", () => {
             }],
             warnings: [],
             usage: noUsage,
+            initialAttendance: [],
+            unmatchedInitialAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -447,6 +449,8 @@ describe("pollDecisions - verification", () => {
             }],
             warnings: [],
             usage: noUsage,
+            initialAttendance: [],
+            unmatchedInitialAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -493,6 +497,8 @@ describe("pollDecisions - verification", () => {
             }],
             warnings: [],
             usage: noUsage,
+            initialAttendance: [],
+            unmatchedInitialAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -534,6 +540,8 @@ describe("pollDecisions - verification", () => {
             }],
             warnings: [],
             usage: noUsage,
+            initialAttendance: [],
+            unmatchedInitialAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -574,6 +582,8 @@ describe("pollDecisions - verification", () => {
             }],
             warnings: [],
             usage: noUsage,
+            initialAttendance: [],
+            unmatchedInitialAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -625,6 +635,8 @@ describe("pollDecisions - verification", () => {
             ],
             warnings: [],
             usage: noUsage,
+            initialAttendance: [],
+            unmatchedInitialAttendance: [],
         });
 
         const result = await pollDecisions(

--- a/src/tasks/pollDecisions.ts
+++ b/src/tasks/pollDecisions.ts
@@ -733,6 +733,8 @@ export const pollDecisions: Task<PollDecisionsRequest, PollDecisionsResult> = as
         extractionResult = {
             decisions: pipelineResult.decisions,
             warnings: pipelineResult.warnings,
+            initialAttendance: pipelineResult.initialAttendance,
+            unmatchedInitialAttendance: pipelineResult.unmatchedInitialAttendance,
         };
     } else if (allExtractionSubjects.length > 0 && (!request.people || request.people.length === 0)) {
         console.log(`Skipping extraction: no people provided for name matching`);

--- a/src/tasks/utils/decisionPdfExtraction.test.ts
+++ b/src/tasks/utils/decisionPdfExtraction.test.ts
@@ -489,7 +489,7 @@ describe('extractDecisionFromPdf', () => {
         fetchSpy.mockRestore();
     });
 
-    it('calls aiChat with correct parameters including maxTokens', async () => {
+    it('calls aiChat with correct model and prefill parameters', async () => {
         const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
             ok: true,
             arrayBuffer: () => Promise.resolve(new ArrayBuffer(50)),
@@ -513,7 +513,6 @@ describe('extractDecisionFromPdf', () => {
 
         expect(mockAiChat).toHaveBeenCalledWith(expect.objectContaining({
             model: 'claude-sonnet-4-20250514',
-            maxTokens: 8192,
             prefillSystemResponse: '{',
             prependToResponse: '{',
         }));

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -106,6 +106,70 @@ export interface AttendanceChange {
 
 export type VoteValue = 'FOR' | 'AGAINST' | 'ABSTAIN' | 'PRESENT' | 'DID_NOT_VOTE';
 
+/**
+ * Raw shape returned by the LLM. The attendance section varies by PDF format:
+ * - "composition_and_absent": PDF lists all members (ΣΥΝΘΕΣΗ) + absent separately
+ * - "explicit_present_absent": PDF has explicit ΠΑΡΟΝΤΕΣ / ΑΠΟΝΤΕΣ lists
+ */
+interface RawLlmExtraction {
+    attendanceFormat: 'composition_and_absent' | 'explicit_present_absent';
+    /** All council members listed in ΣΥΝΘΕΣΗ — only when attendanceFormat is "composition_and_absent" */
+    compositionMembers: string[] | null;
+    /** Members from ΠΑΡΟΝΤΕΣ list — only when attendanceFormat is "explicit_present_absent" */
+    presentMembers: string[] | null;
+    /** Members from ΑΠΟΝΤΕΣ / "απουσίαζαν" list — always present */
+    absentMembers: string[];
+    mayorPresent: { present: boolean; rawText: string } | null;
+    decisionExcerpt: string;
+    decisionNumber: string | null;
+    references: string;
+    voteResult: string | null;
+    voteDetails: { name: string; vote: VoteValue }[];
+    attendanceChanges: AttendanceChange[];
+    discussionOrder: AgendaItemRef[] | null;
+    subjectInfo: AgendaItemRef | null;
+    incomplete: boolean;
+}
+
+/**
+ * Normalize the LLM extraction into the standard shape used by the pipeline.
+ * When the PDF uses "composition + absent" format, computes present = composition - absent
+ * so the LLM doesn't have to do any subtraction.
+ */
+function normalizeExtraction(raw: RawLlmExtraction): RawExtractedDecision {
+    let presentMembers: string[];
+    let absentMembers = raw.absentMembers || [];
+
+    if (raw.attendanceFormat === 'composition_and_absent') {
+        if (raw.compositionMembers && raw.compositionMembers.length > 0) {
+            // Compute present = composition - absent using normalizeGreekName for robust matching
+            // (handles diacritics/tonos, parenthetical nicknames, whitespace differences)
+            const absentNormalized = new Set(absentMembers.map(n => normalizeGreekName(n)));
+            presentMembers = raw.compositionMembers.filter(n => !absentNormalized.has(normalizeGreekName(n)));
+        } else {
+            console.warn('⚠ LLM returned attendanceFormat "composition_and_absent" but compositionMembers is empty — attendance may be incomplete');
+            presentMembers = raw.presentMembers || [];
+        }
+    } else {
+        presentMembers = raw.presentMembers || [];
+    }
+
+    return {
+        presentMembers,
+        absentMembers,
+        mayorPresent: raw.mayorPresent,
+        decisionExcerpt: raw.decisionExcerpt,
+        decisionNumber: raw.decisionNumber,
+        references: raw.references,
+        voteResult: raw.voteResult,
+        voteDetails: raw.voteDetails,
+        attendanceChanges: raw.attendanceChanges,
+        discussionOrder: raw.discussionOrder,
+        subjectInfo: raw.subjectInfo,
+        incomplete: raw.incomplete,
+    };
+}
+
 export interface RawExtractedDecision {
     presentMembers: string[];
     absentMembers: string[];
@@ -167,21 +231,23 @@ const EXTRACTION_SYSTEM_PROMPT = `You are a document parser for Greek municipal 
 
 Extract the following information from the PDF:
 
-1. **presentMembers**: List of council members who were present at the START of the session — the initial roll call used to establish quorum (απαρτία). Extract just their full names. These are the members present BEFORE any arrivals or departures listed in the "Προσελεύσεις – Αποχωρήσεις" section. PDFs use two formats:
-   - **Explicit ΠΑΡΟΝΤΕΣ section**: A list headed "Παρόντες" or "Συμμετέχοντες-Παρόντες" — extract those names directly.
-   - **Composition + Absent format**: A "ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ" section listing ALL members, followed by a separate "απουσίαζαν" / "ΑΠΟΝΤΕΣ" section listing absent members. In this case, presentMembers = all members from the composition list MINUS the absent members. Do NOT include members who arrived later (from "Προσελεύσεις").
-2. **absentMembers**: List of council members who were absent at the START of the session (ΑΠΟΝΤΕΣ / "απουσίαζαν"). Extract just their full names. Do NOT remove someone from this list just because they arrived later (Προσελεύσεις) — that information goes in attendanceChanges.
-3. **decisionExcerpt**: The decision text, starting from "ΤΟ Δ.Σ αφού έλαβε υπόψη" or similar phrasing through "ΑΠΟΦΑΣΙΖΕΙ" and the decision content. Include the full decision text. Use markdown formatting to preserve structure (bullet points, numbered lists, etc.). Preserve bold formatting from the PDF — if text is bold in the original, wrap it in **bold** markdown. The "decides" statement (e.g. "ΑΠΟΦΑΣΙΖΕΙ", "Το Δημοτικό Συμβούλιο … αποφασίζει ομόφωνα") must be its own paragraph — keep the full sentence on one line, separated by blank lines from surrounding text, not merged with the decision content that follows.
-4. **decisionNumber**: The decision number (Αριθμός Απόφασης), e.g. "231/2025".
-5. **references**: The legal bases and references from the "αφού έλαβε υπόψη" or "Έχοντας υπόψη" section. List each reference item. Use markdown formatting (numbered list). If the section just says something generic like "τις σχετικές διατάξεις της Νομοθεσίας", return that text as-is.
-6. **voteResult**: The vote result phrase, e.g. "Ομόφωνα", "Κατά πλειοψηφία", "Κατά πλειοψηφία με ψήφους 21 υπέρ και 2 κατά". This is usually found right before or after "ΑΠΟΦΑΣΙΖΕΙ".
-7. **voteDetails**: When the PDF names specific people who voted differently (against or abstained) or made declarations (present/non-participation), list them. For unanimous decisions, return an empty array. Each entry has "name" (full name) and "vote":
+1. **attendanceFormat**: How attendance is structured in this PDF. One of:
+   - "composition_and_absent" — The PDF has a "ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ" section listing ALL council members, followed by a separate "απουσίαζαν" / "ΑΠΟΝΤΕΣ" section listing absent members.
+   - "explicit_present_absent" — The PDF has separate "Παρόντες" / "ΠΑΡΟΝΤΕΣ" and "Απόντες" / "ΑΠΟΝΤΕΣ" lists.
+2. **compositionMembers**: When attendanceFormat is "composition_and_absent", extract ALL names from the ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ section — this is the complete council membership. Set to null when attendanceFormat is "explicit_present_absent".
+3. **presentMembers**: When attendanceFormat is "explicit_present_absent", extract names from the ΠΑΡΟΝΤΕΣ list. Set to null when attendanceFormat is "composition_and_absent".
+4. **absentMembers**: Names from the ΑΠΟΝΤΕΣ / "απουσίαζαν" section. Always extract this regardless of format. Do NOT remove someone from this list just because they arrived later (Προσελεύσεις) — that information goes in attendanceChanges.
+5. **decisionExcerpt**: The decision text, starting from "ΤΟ Δ.Σ αφού έλαβε υπόψη" or similar phrasing through "ΑΠΟΦΑΣΙΖΕΙ" and the decision content. Include the full decision text — do not skip or omit any sections. Use markdown formatting to preserve structure (tables, bullet points, numbered lists, etc.). When the PDF contains tabular data, render it as a markdown table with all rows including summary/total rows. Not all tables follow the same columnar format — budget amendments may include title-change tables (ΑΠΟ/ΣΕ), revenue limit tables, or other non-standard layouts. Represent these faithfully using the most appropriate markdown structure (table, list, or formatted text). Preserve bold formatting from the PDF — if text is bold in the original, wrap it in **bold** markdown. The "decides" statement (e.g. "ΑΠΟΦΑΣΙΖΕΙ", "Το Δημοτικό Συμβούλιο … αποφασίζει ομόφωνα") must be its own paragraph — keep the full sentence on one line, separated by blank lines from surrounding text, not merged with the decision content that follows.
+6. **decisionNumber**: The decision number (Αριθμός Απόφασης), e.g. "231/2025".
+7. **references**: The legal bases and references from the "αφού έλαβε υπόψη" or "Έχοντας υπόψη" section. List each reference item. Use markdown formatting (numbered list). If the section just says something generic like "τις σχετικές διατάξεις της Νομοθεσίας", return that text as-is.
+8. **voteResult**: The vote result phrase, e.g. "Ομόφωνα", "Κατά πλειοψηφία", "Κατά πλειοψηφία με ψήφους 21 υπέρ και 2 κατά". This is usually found right before or after "ΑΠΟΦΑΣΙΖΕΙ".
+9. **voteDetails**: When the PDF names specific people who voted differently (against or abstained) or made declarations (present/non-participation), list them. For unanimous decisions, return an empty array. Each entry has "name" (full name) and "vote":
    - "FOR" (ΥΠΕΡ) — voted in favor
    - "AGAINST" (ΚΑΤΑ) — voted against
    - "ABSTAIN" (ΛΕΥΚΟ) — blank vote, no position taken (still a vote)
    - "PRESENT" (ΠΑΡΩΝ/ΠΑΡΟΥΣΑ) — declared physical presence but did not participate in the vote (declaration, not a vote)
    - "DID_NOT_VOTE" (ΑΠΟΧΗ) — declined to participate (declaration, not a vote)
-8. **attendanceChanges**: Extract from "Προσελεύσεις – Αποχωρήσεις" or separate "Προσελεύσεις" / "Αποχωρήσεις" sections. These describe members who arrived late or left early. For each person, extract:
+10. **attendanceChanges**: Extract from "Προσελεύσεις – Αποχωρήσεις" or separate "Προσελεύσεις" / "Αποχωρήσεις" sections. These describe members who arrived late or left early. For each person, extract:
    - "name": full name
    - "type": "arrival" or "departure"
    - "agendaItem": The agenda item during/after which this change occurred. Use an object with:
@@ -195,21 +261,23 @@ Extract the following information from the PDF:
      The distinction matters: "after item 9" means the person was present and voted on item 9, while "during item 9" means they left/arrived partway through.
    - "rawText": the original sentence describing this change.
    If no such section exists, return an empty array.
-9. **discussionOrder**: When subjects were discussed out of the standard agenda order (e.g. "Προτάθηκε η αλλαγή σειράς συζήτησης", items reordered, or out-of-agenda items inserted between regular items), extract the full discussion sequence including both regular and out-of-agenda/emergency items. Each entry is an object with:
+11. **discussionOrder**: When subjects were discussed out of the standard agenda order (e.g. "Προτάθηκε η αλλαγή σειράς συζήτησης", items reordered, or out-of-agenda items inserted between regular items), extract the full discussion sequence including both regular and out-of-agenda/emergency items. Each entry is an object with:
    - "agendaItemIndex": the item number
    - "nonAgendaReason": "outOfAgenda" if the item is an out-of-agenda/emergency item (ΕΚΤΑΚΤΟ ΘΕΜΑ), otherwise null
    Example: if regular item 1 was discussed first, then 3 out-of-agenda items, then regular item 9 was brought forward, the sequence would be: [{"agendaItemIndex":1,"nonAgendaReason":null},{"agendaItemIndex":1,"nonAgendaReason":"outOfAgenda"},{"agendaItemIndex":2,"nonAgendaReason":"outOfAgenda"},{"agendaItemIndex":3,"nonAgendaReason":"outOfAgenda"},{"agendaItemIndex":9,"nonAgendaReason":null},...].
    Return null if subjects were discussed in standard agenda order with no out-of-agenda items interleaved.
-10. **subjectInfo**: The agenda item this decision relates to:
+12. **subjectInfo**: The agenda item this decision relates to:
    - "agendaItemIndex": The subject/topic number (e.g., "ΘΕΜΑ 3ο" → 3, "1ο ΕΚΤΑΚΤΟ ΘΕΜΑ" → 1, "ΘΕΜΑ ΕΚΤΟΣ Η.Δ. 2ο" → 2)
    - "nonAgendaReason": "outOfAgenda" if this is an out-of-agenda/emergency item (ΕΚΤΑΚΤΟ ΘΕΜΑ, ΘΕΜΑ ΕΚΤΟΣ Η.Δ., etc.), null for regular agenda items (ΘΕΜΑ Η.Δ., τακτικό θέμα)
    - Return null if the subject/topic number cannot be determined.
-11. **mayorPresent**: Whether the city mayor (Δήμαρχος/Δήμαρχο) was present at the session. This is usually stated in a narrative paragraph separate from the council member attendance list. Look for phrases like "Ο/Η Δήμαρχος ... προσκλήθηκε νομίμως και παρέστη" or "Ο/Η Δήμαρχος ... παρών/παρούσα" (present), or "Ο/Η Δήμαρχος ... δεν ήταν παρών/παρούσα" or "απουσίαζε" (absent). Return an object with "present" (boolean) and "rawText" (the original sentence from the PDF describing the mayor's presence/absence). Return null if mayor presence is not mentioned.
-12. **incomplete**: Set to true ONLY if the document appears physically truncated — i.e. you can see attendance lists and preamble but the decision section starting with "ΑΠΟΦΑΣΙΖΕΙ" is not present because the provided pages end before reaching it. Set to false if you can see the "ΑΠΟΦΑΣΙΖΕΙ" section, even if some fields within it (like the vote result phrase) are missing or unclear. Missing data in a complete document is a data quality issue, not truncation.
+13. **mayorPresent**: Whether the city mayor (Δήμαρχος/Δήμαρχο) was present at the session. This is usually stated in a narrative paragraph separate from the council member attendance list. Look for phrases like "Ο/Η Δήμαρχος ... προσκλήθηκε νομίμως και παρέστη" or "Ο/Η Δήμαρχος ... παρών/παρούσα" (present), or "Ο/Η Δήμαρχος ... δεν ήταν παρών/παρούσα" or "απουσίαζε" (absent). Return an object with "present" (boolean) and "rawText" (the original sentence from the PDF describing the mayor's presence/absence). Return null if mayor presence is not mentioned.
+14. **incomplete**: Set to true ONLY if the document appears physically truncated — i.e. you can see attendance lists and preamble but the decision section starting with "ΑΠΟΦΑΣΙΖΕΙ" is not present because the provided pages end before reaching it. Set to false if you can see the "ΑΠΟΦΑΣΙΖΕΙ" section, even if some fields within it (like the vote result phrase) are missing or unclear. Missing data in a complete document is a data quality issue, not truncation.
 
 Return valid JSON matching this schema:
 {
-  "presentMembers": string[],
+  "attendanceFormat": "composition_and_absent" | "explicit_present_absent",
+  "compositionMembers": string[] | null,
+  "presentMembers": string[] | null,
   "absentMembers": string[],
   "mayorPresent": { "present": boolean, "rawText": string } | null,
   "decisionExcerpt": string,
@@ -457,8 +525,8 @@ export async function matchAllMembers(
 // --- PDF extraction ---
 
 const EXTRACTION_MODEL = 'claude-sonnet-4-20250514';
-/** Max output tokens for extraction — the JSON output is small, so we don't need the full 64k default. */
-const EXTRACTION_MAX_TOKENS = 8192;
+/** Max output tokens for extraction — needs headroom for decisions with large tables (budget amendments, etc.). */
+const EXTRACTION_MAX_TOKENS = 16384;
 
 /** Page count threshold: PDFs with this many pages or fewer are sent whole. */
 const SMALL_PDF_THRESHOLD = 10;
@@ -495,7 +563,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
     if (totalPages <= SMALL_PDF_THRESHOLD) {
         console.log(`  PDF has ${totalPages} pages (≤${SMALL_PDF_THRESHOLD}), sending whole document`);
         const base64 = pdfBuffer.toString('base64');
-        const { result, usage } = await aiChat<RawExtractedDecision>({
+        const { result: raw, usage } = await aiChat<RawLlmExtraction>({
             systemPrompt: EXTRACTION_SYSTEM_PROMPT,
             userPrompt,
             documentBase64: base64,
@@ -505,6 +573,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             maxTokens: EXTRACTION_MAX_TOKENS,
         });
 
+        const result = normalizeExtraction(raw);
         writeCache(pdfUrl, result);
         return { result, usage, fromCache: false };
     }
@@ -525,7 +594,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             ? `${userPrompt}\n\nNote: You are seeing pages 1-${actualPages} of a ${totalPages}-page document. If the decision section ("ΑΠΟΦΑΣΙΖΕΙ") is not visible in these pages because the document is cut off, set "incomplete" to true. If you can see "ΑΠΟΦΑΣΙΖΕΙ" but some details are missing or unclear, set "incomplete" to false.`
             : userPrompt;
 
-        const { result, usage } = await aiChat<RawExtractedDecision>({
+        const { result: raw, usage } = await aiChat<RawLlmExtraction>({
             systemPrompt: EXTRACTION_SYSTEM_PROMPT,
             userPrompt: partialPrompt,
             documentBase64: partialBase64,
@@ -536,6 +605,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
         });
 
         totalUsage = addUsage(totalUsage, usage);
+        const result = normalizeExtraction(raw);
         lastFrontResult = result;
 
         if (!result.incomplete || actualPages >= totalPages) {
@@ -562,7 +632,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
         const tailBase64 = await extractPdfPages(pdfBuffer, tailStart, totalPages);
         const tailPrompt = `${userPrompt}\n\nNote: You are seeing the last ${tailActual} pages (${tailStart + 1}-${totalPages}) of a ${totalPages}-page document. The earlier pages contained attendance lists and preamble but not the decision section. Extract the decision information from these pages. If the decision section ("ΑΠΟΦΑΣΙΖΕΙ") is not visible in these pages either, set "incomplete" to true.`;
 
-        const { result, usage } = await aiChat<RawExtractedDecision>({
+        const { result: tailRaw, usage } = await aiChat<RawLlmExtraction>({
             systemPrompt: EXTRACTION_SYSTEM_PROMPT,
             userPrompt: tailPrompt,
             documentBase64: tailBase64,
@@ -573,17 +643,18 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
         });
 
         totalUsage = addUsage(totalUsage, usage);
+        const tailResult = normalizeExtraction(tailRaw);
 
-        if (!result.incomplete) {
+        if (!tailResult.incomplete) {
             // Merge: attendance + preamble from front pages, decision data from tail pages
             const merged: RawExtractedDecision = {
-                ...result,
-                presentMembers: result.presentMembers?.length ? result.presentMembers : lastFrontResult!.presentMembers,
-                absentMembers: result.absentMembers?.length ? result.absentMembers : lastFrontResult!.absentMembers,
-                attendanceChanges: result.attendanceChanges?.length ? result.attendanceChanges : lastFrontResult!.attendanceChanges,
-                mayorPresent: result.mayorPresent ?? lastFrontResult!.mayorPresent,
-                discussionOrder: result.discussionOrder ?? lastFrontResult!.discussionOrder,
-                subjectInfo: result.subjectInfo ?? lastFrontResult!.subjectInfo,
+                ...tailResult,
+                presentMembers: tailResult.presentMembers?.length ? tailResult.presentMembers : lastFrontResult!.presentMembers,
+                absentMembers: tailResult.absentMembers?.length ? tailResult.absentMembers : lastFrontResult!.absentMembers,
+                attendanceChanges: tailResult.attendanceChanges?.length ? tailResult.attendanceChanges : lastFrontResult!.attendanceChanges,
+                mayorPresent: tailResult.mayorPresent ?? lastFrontResult!.mayorPresent,
+                discussionOrder: tailResult.discussionOrder ?? lastFrontResult!.discussionOrder,
+                subjectInfo: tailResult.subjectInfo ?? lastFrontResult!.subjectInfo,
             };
             console.log(`  Extraction complete from tail pages (merged with front-page attendance)`);
             writeCache(pdfUrl, merged);

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -104,6 +104,8 @@ export interface AttendanceChange {
     rawText: string;
 }
 
+export type VoteValue = 'FOR' | 'AGAINST' | 'ABSTAIN' | 'PRESENT' | 'DID_NOT_VOTE';
+
 export interface RawExtractedDecision {
     presentMembers: string[];
     absentMembers: string[];
@@ -112,7 +114,7 @@ export interface RawExtractedDecision {
     decisionNumber: string | null;
     references: string;
     voteResult: string | null;
-    voteDetails: { name: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' }[];
+    voteDetails: { name: string; vote: VoteValue }[];
     attendanceChanges: AttendanceChange[];
     discussionOrder: AgendaItemRef[] | null;
     subjectInfo: AgendaItemRef | null;
@@ -127,14 +129,18 @@ export interface RawExtractedDecision {
  * - **Majority** ("κατά πλειοψηφία"): only AGAINST/ABSTAIN voters are named;
  *   all present members not in voteDetails are implicitly FOR.
  *
+ * Members with any explicit voteDetails entry — including PRESENT (Παρών)
+ * and DID_NOT_VOTE (Αποχή) declarations — are not given inferred FOR votes,
+ * since they're already in the explicit voter set.
+ *
  * Pure function: returns a new voteDetails array (never mutates input) and the
  * number of inferred FOR votes.
  */
 export function inferForVotes(
     presentMembers: string[],
     voteResult: string | null,
-    voteDetails: { name: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' }[],
-): { voteDetails: { name: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' }[]; inferredCount: number } {
+    voteDetails: { name: string; vote: VoteValue }[],
+): { voteDetails: { name: string; vote: VoteValue }[]; inferredCount: number } {
     const isUnanimous = voteResult && /[οό]μ[οό]φων/i.test(voteResult);
     const isMajority = voteResult && /κατ[άα]\s+πλειοψηφ[ίι]/i.test(voteResult);
     const hasNoForVotes = (voteDetails || []).every(v => v.vote !== 'FOR');
@@ -161,13 +167,20 @@ const EXTRACTION_SYSTEM_PROMPT = `You are a document parser for Greek municipal 
 
 Extract the following information from the PDF:
 
-1. **presentMembers**: List of council members marked as present (ΠΑΡΟΝΤΕΣ). Extract just their full names.
-2. **absentMembers**: List of council members marked as absent (ΑΠΟΝΤΕΣ). Extract just their full names.
+1. **presentMembers**: List of council members who were present at the START of the session — the initial roll call used to establish quorum (απαρτία). Extract just their full names. These are the members present BEFORE any arrivals or departures listed in the "Προσελεύσεις – Αποχωρήσεις" section. PDFs use two formats:
+   - **Explicit ΠΑΡΟΝΤΕΣ section**: A list headed "Παρόντες" or "Συμμετέχοντες-Παρόντες" — extract those names directly.
+   - **Composition + Absent format**: A "ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ" section listing ALL members, followed by a separate "απουσίαζαν" / "ΑΠΟΝΤΕΣ" section listing absent members. In this case, presentMembers = all members from the composition list MINUS the absent members. Do NOT include members who arrived later (from "Προσελεύσεις").
+2. **absentMembers**: List of council members who were absent at the START of the session (ΑΠΟΝΤΕΣ / "απουσίαζαν"). Extract just their full names. Do NOT remove someone from this list just because they arrived later (Προσελεύσεις) — that information goes in attendanceChanges.
 3. **decisionExcerpt**: The decision text, starting from "ΤΟ Δ.Σ αφού έλαβε υπόψη" or similar phrasing through "ΑΠΟΦΑΣΙΖΕΙ" and the decision content. Include the full decision text. Use markdown formatting to preserve structure (bullet points, numbered lists, etc.). Preserve bold formatting from the PDF — if text is bold in the original, wrap it in **bold** markdown. The "decides" statement (e.g. "ΑΠΟΦΑΣΙΖΕΙ", "Το Δημοτικό Συμβούλιο … αποφασίζει ομόφωνα") must be its own paragraph — keep the full sentence on one line, separated by blank lines from surrounding text, not merged with the decision content that follows.
 4. **decisionNumber**: The decision number (Αριθμός Απόφασης), e.g. "231/2025".
 5. **references**: The legal bases and references from the "αφού έλαβε υπόψη" or "Έχοντας υπόψη" section. List each reference item. Use markdown formatting (numbered list). If the section just says something generic like "τις σχετικές διατάξεις της Νομοθεσίας", return that text as-is.
 6. **voteResult**: The vote result phrase, e.g. "Ομόφωνα", "Κατά πλειοψηφία", "Κατά πλειοψηφία με ψήφους 21 υπέρ και 2 κατά". This is usually found right before or after "ΑΠΟΦΑΣΙΖΕΙ".
-7. **voteDetails**: When the PDF names specific people who voted differently (against or abstained), list them. For unanimous decisions, return an empty array. Each entry has "name" (full name) and "vote" ("FOR", "AGAINST", or "ABSTAIN").
+7. **voteDetails**: When the PDF names specific people who voted differently (against or abstained) or made declarations (present/non-participation), list them. For unanimous decisions, return an empty array. Each entry has "name" (full name) and "vote":
+   - "FOR" (ΥΠΕΡ) — voted in favor
+   - "AGAINST" (ΚΑΤΑ) — voted against
+   - "ABSTAIN" (ΛΕΥΚΟ) — blank vote, no position taken (still a vote)
+   - "PRESENT" (ΠΑΡΩΝ/ΠΑΡΟΥΣΑ) — declared physical presence but did not participate in the vote (declaration, not a vote)
+   - "DID_NOT_VOTE" (ΑΠΟΧΗ) — declined to participate (declaration, not a vote)
 8. **attendanceChanges**: Extract from "Προσελεύσεις – Αποχωρήσεις" or separate "Προσελεύσεις" / "Αποχωρήσεις" sections. These describe members who arrived late or left early. For each person, extract:
    - "name": full name
    - "type": "arrival" or "departure"
@@ -203,7 +216,7 @@ Return valid JSON matching this schema:
   "decisionNumber": string | null,
   "references": string,
   "voteResult": string | null,
-  "voteDetails": { "name": string, "vote": "FOR" | "AGAINST" | "ABSTAIN" }[],
+  "voteDetails": { "name": string, "vote": "FOR" | "AGAINST" | "ABSTAIN" | "PRESENT" | "DID_NOT_VOTE" }[],
   "attendanceChanges": { "name": string, "type": "arrival" | "departure", "agendaItem": { "agendaItemIndex": number, "nonAgendaReason": "outOfAgenda" | null } | null, "timing": "during" | "after" | null, "rawText": string }[],
   "discussionOrder": { "agendaItemIndex": number, "nonAgendaReason": "outOfAgenda" | null }[] | null,
   "subjectInfo": { "agendaItemIndex": number, "nonAgendaReason": "outOfAgenda" | null } | null,

--- a/src/tasks/utils/decisionValidation.ts
+++ b/src/tasks/utils/decisionValidation.ts
@@ -1,4 +1,4 @@
-import { RawExtractedDecision } from './decisionPdfExtraction.js';
+import { RawExtractedDecision, VoteValue } from './decisionPdfExtraction.js';
 
 // --- Warning types ---
 
@@ -94,7 +94,7 @@ export function validateRawExtraction(raw: RawExtractedDecision): DecisionWarnin
 
 export interface ProcessedDecisionContext {
     voteResult: string | null;
-    voteDetails: { vote: 'FOR' | 'AGAINST' | 'ABSTAIN' }[];
+    voteDetails: { vote: VoteValue }[];
 }
 
 /**
@@ -104,15 +104,17 @@ export interface ProcessedDecisionContext {
 export function validateProcessedDecision(ctx: ProcessedDecisionContext): DecisionWarning[] {
     const warnings: DecisionWarning[] = [];
 
-    // Majority vote but no AGAINST/ABSTAIN voters listed
+    // Majority vote but no non-FOR votes or declarations listed
     const isMajority = ctx.voteResult && /κατ[άα]\s+πλειοψηφ[ίι]/i.test(ctx.voteResult);
     if (isMajority) {
-        const hasOppositionVotes = ctx.voteDetails.some(v => v.vote === 'AGAINST' || v.vote === 'ABSTAIN');
-        if (!hasOppositionVotes) {
+        const hasNonForVotes = ctx.voteDetails.some(v =>
+            v.vote === 'AGAINST' || v.vote === 'ABSTAIN' || v.vote === 'PRESENT' || v.vote === 'DID_NOT_VOTE'
+        );
+        if (!hasNonForVotes) {
             warnings.push({
                 code: 'NO_VOTE_DETAILS',
                 severity: 'warning',
-                message: 'Vote result indicates majority but no AGAINST or ABSTAIN voters were found',
+                message: 'Vote result indicates majority but no AGAINST, ABSTAIN, PRESENT or DID_NOT_VOTE voters were found',
             });
         }
     }

--- a/src/tasks/utils/effectiveAttendance.ts
+++ b/src/tasks/utils/effectiveAttendance.ts
@@ -1,4 +1,4 @@
-import { AttendanceChange, AgendaItemRef, RawExtractedDecision, inferForVotes } from './decisionPdfExtraction.js';
+import { AttendanceChange, AgendaItemRef, RawExtractedDecision, VoteValue, inferForVotes } from './decisionPdfExtraction.js';
 
 function agendaItemRefEquals(a: AgendaItemRef, b: AgendaItemRef): boolean {
     return a.agendaItemIndex === b.agendaItemIndex && a.nonAgendaReason === b.nonAgendaReason;
@@ -126,7 +126,7 @@ export function computeEffectiveAttendance(input: EffectiveAttendanceInput): {
 export interface ProcessedExtraction {
     effectivePresent: string[];
     effectiveAbsent: string[];
-    voteDetails: { name: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' }[];
+    voteDetails: { name: string; vote: VoteValue }[];
     inferredVoteCount: number;
 }
 

--- a/src/tasks/utils/extractionPipeline.ts
+++ b/src/tasks/utils/extractionPipeline.ts
@@ -26,6 +26,10 @@ export interface ExtractionPipelineResult {
     decisions: ExtractedDecisionResult[];
     warnings: string[];
     usage: Anthropic.Messages.Usage;
+    /** Initial roll call — who was present/absent at session start (meeting-level, not per-subject) */
+    initialAttendance: { personId: string; status: 'PRESENT' | 'ABSENT' }[];
+    /** Names from the initial roll call that couldn't be matched to any person in the database */
+    unmatchedInitialAttendance: string[];
 }
 
 const BATCH_SIZE = 5;
@@ -58,7 +62,7 @@ export async function extractDecisionsFromPdfs(
     if (mayorName) console.log(`Mayor: ${mayorName} (${mayorId})`);
 
     if (subjects.length === 0) {
-        return { decisions: [], warnings: [], usage: totalUsage };
+        return { decisions: [], warnings: [], usage: totalUsage, initialAttendance: [], unmatchedInitialAttendance: [] };
     }
 
     // --- Phase 1: Extract all PDFs (batched for concurrency) ---
@@ -156,6 +160,44 @@ export async function extractDecisionsFromPdfs(
 
     console.log(`  Final matched: ${nameToPersonId.size}/${allRawNames.size}`);
 
+    // --- Build meeting-level initial attendance from the first extraction with roll call data ---
+    // All PDFs from the same meeting have the same initial roll, so we use the first one.
+    const initialAttendance: ExtractionPipelineResult['initialAttendance'] = [];
+    const firstWithRoll = extractions.find(e => (e.raw.presentMembers?.length ?? 0) > 0 || (e.raw.absentMembers?.length ?? 0) > 0);
+    const unmatchedInitialAttendance: string[] = [];
+    if (firstWithRoll) {
+        for (const name of firstWithRoll.raw.presentMembers || []) {
+            const personId = nameToPersonId.get(name);
+            if (personId) initialAttendance.push({ personId, status: 'PRESENT' });
+            else unmatchedInitialAttendance.push(name);
+        }
+        for (const name of firstWithRoll.raw.absentMembers || []) {
+            const personId = nameToPersonId.get(name);
+            if (personId) initialAttendance.push({ personId, status: 'ABSENT' });
+            else unmatchedInitialAttendance.push(name);
+        }
+        // Include mayor if extracted from decision narrative
+        let mayorAdded = false;
+        if (firstWithRoll.raw.mayorPresent?.present != null && mayorId) {
+            if (!initialAttendance.some(a => a.personId === mayorId)) {
+                initialAttendance.push({ personId: mayorId, status: firstWithRoll.raw.mayorPresent.present ? 'PRESENT' : 'ABSENT' });
+                mayorAdded = true;
+            }
+        }
+        const presentCount = initialAttendance.filter(a => a.status === 'PRESENT').length;
+        const absentCount = initialAttendance.filter(a => a.status === 'ABSENT').length;
+        const totalExtracted = (firstWithRoll.raw.presentMembers?.length ?? 0) + (firstWithRoll.raw.absentMembers?.length ?? 0);
+        const matchedCount = presentCount + absentCount;
+        const mayorNote = mayorAdded ? ' (includes mayor from narrative)' : '';
+        console.log(`  Initial attendance: ${presentCount} present, ${absentCount} absent — ${matchedCount} matched from ${totalExtracted} extracted${mayorNote}`);
+        if (unmatchedInitialAttendance.length > 0) {
+            console.warn(`  ⚠ ${unmatchedInitialAttendance.length} unmatched members in initial roll call:`);
+            for (const name of unmatchedInitialAttendance) {
+                console.warn(`    - "${name}"`);
+            }
+        }
+    }
+
     // --- Phase 3: Build decision results using the name→personId map ---
     // Each PDF is self-contained: build allAgendaItemNumbers from its own data
     const decisions: ExtractedDecisionResult[] = [];
@@ -226,7 +268,10 @@ export async function extractDecisionsFromPdfs(
             protocolNumber: raw.decisionNumber || null,
         });
 
-        console.log(`  [${subjectId}] ${presentMemberIds.length} present, ${absentMemberIds.length} absent, ${unmatchedMembers.length} unmatched, ${voteDetails.length} votes`);
+        console.log(`  [${subjectId}] ${presentMemberIds.length} present, ${absentMemberIds.length} absent, ${voteDetails.length} votes`);
+        if (dedupedUnmatched.length > 0) {
+            console.warn(`  ⚠ [${subjectId}] ${dedupedUnmatched.length} unmatched members: ${dedupedUnmatched.map(n => `"${n}"`).join(', ')}`);
+        }
     }
 
     const totalElapsed = ((Date.now() - taskStart) / 1000).toFixed(1);
@@ -234,5 +279,5 @@ export async function extractDecisionsFromPdfs(
     console.log(`  Extracted: ${extractions.length}/${subjects.length}`);
     console.log(`  Warnings: ${warnings.length}`);
 
-    return { decisions, warnings, usage: totalUsage };
+    return { decisions, warnings, usage: totalUsage, initialAttendance, unmatchedInitialAttendance };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,7 +429,7 @@ export interface ExtractedDecisionResult {
     absentMemberIds: string[];
     mayorPresent?: boolean;
     voteResult: string | null;
-    voteDetails: { personId: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' }[];
+    voteDetails: { personId: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' | 'PRESENT' | 'DID_NOT_VOTE' }[];
     unmatchedMembers: string[];
     subjectInfo: { number: number; isOutOfAgenda: boolean } | null;
     fromCache?: boolean;
@@ -499,6 +499,10 @@ export interface PollDecisionsResult {
     extractions: {
         decisions: ExtractedDecisionResult[];
         warnings: string[];
+        /** Initial roll call — who was present/absent at session start (meeting-level, not per-subject) */
+        initialAttendance: { personId: string; status: 'PRESENT' | 'ABSENT' }[];
+        /** Names from the initial roll call that couldn't be matched to any person in the database */
+        unmatchedInitialAttendance: string[];
     } | null;
     costs: {
         input_tokens: number;


### PR DESCRIPTION
## Summary

- Expose initial roll call (`initialAttendance`) as a meeting-level field on extraction results — previously extracted but discarded during per-subject computation
- Refactor LLM prompt to extract raw PDF attendance format instead of asking the LLM to compute present = composition - absent (fixes silent member drops)
- Extend vote types with PRESENT (Παρών) and DID_NOT_VOTE (Αποχή) in extraction prompt and inference logic
- Track and log unmatched members in initial attendance with ⚠ warnings

## Context

Companion to the opencouncil PR. See [#173 status update](https://github.com/schemalabz/opencouncil/issues/173#issuecomment-4380781189).

## Test plan

- [ ] Extract decisions for a "composition + absent" format city (e.g. Zografou) — verify full council in initialAttendance
- [ ] Extract decisions for an "explicit present/absent" format city (e.g. Vrilissia) — verify correct attendance
- [ ] Check logs for ⚠ warnings when members are unmatched
- [ ] Verify `unmatchedInitialAttendance` appears in response

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the LLM extraction prompt to preserve the raw PDF attendance format (`composition_and_absent` vs `explicit_present_absent`) and compute `present = composition − absent` in code, eliminating the class of silent member drops that occurred when the LLM performed the subtraction itself. It also exposes the meeting-level initial roll call (`initialAttendance`) as a first-class output alongside the per-subject decision results.

- **Extraction refactor**: New `RawLlmExtraction` type captures the raw format; `normalizeExtraction()` performs the subtraction using `normalizeGreekName` for diacritic-safe matching; `PRESENT`/`DID_NOT_VOTE` vote types are added throughout the pipeline.
- **Initial attendance passthrough**: `extractionPipeline.ts` derives `initialAttendance` from the first extraction with roll call data and surfaces unmatched names as `unmatchedInitialAttendance` with `console.warn` logging.
- **Validation fix**: `validateProcessedDecision` now correctly includes `PRESENT` and `DID_NOT_VOTE` in the `hasNonForVotes` guard, preventing spurious `NO_VOTE_DETAILS` warnings for majority decisions where members declared non-participation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic changes are well-scoped and the extraction refactor addresses previously identified silent-drop bugs.

The core attendance normalization is correct: normalizeGreekName is used consistently for name comparison, normalizeExtraction is called at all three PDF extraction paths, and the nameToPersonId lookup in the initial attendance block draws from the same map built during Phase 2 matching. All previously flagged issues have been addressed. The only findings are a duplicated vote-type union in types.ts and a missing deduplication pass on unmatchedInitialAttendance — both low impact.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/tasks/utils/decisionPdfExtraction.ts | Introduces RawLlmExtraction type with attendanceFormat/compositionMembers, normalizeExtraction() computes present = composition - absent using normalizeGreekName; adds PRESENT/DID_NOT_VOTE to VoteValue; doubles maxTokens to 16384 |
| src/tasks/utils/extractionPipeline.ts | Adds meeting-level initialAttendance/unmatchedInitialAttendance to pipeline result; picks the first extraction with roll call data, looks up matched personIds, logs unmatched names with warnings |
| src/tasks/utils/decisionValidation.ts | Updates hasOppositionVotes to hasNonForVotes, now includes PRESENT and DID_NOT_VOTE — fixes spurious NO_VOTE_DETAILS warnings for majority decisions |
| src/types.ts | Adds initialAttendance/unmatchedInitialAttendance to PollDecisionsResult.extractions; extends voteDetails vote union inline with PRESENT/DID_NOT_VOTE (duplicates VoteValue rather than importing it) |
| src/tasks/pollDecisions.ts | Passes through initialAttendance and unmatchedInitialAttendance from pipeline result into extractionResult; minimal, correct change |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/tasks/utils/decisionValidation.ts`, line 110 ([link](https://github.com/schemalabz/opencouncil-tasks/blob/acfc448d05eae9c85192ec836f462c236a5f77a3/src/tasks/utils/decisionValidation.ts#L110)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The `hasOppositionVotes` guard was not updated alongside the new vote types. A "κατά πλειοψηφία" decision where all non-FOR participants declared DID_NOT_VOTE (Αποχή) or PRESENT (Παρών) — valid under the new vote model — will still trip this check and emit a spurious `NO_VOTE_DETAILS` warning, because neither `DID_NOT_VOTE` nor `PRESENT` is counted as "opposition". This was the exact type of non-participation that the new vote types were introduced to represent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/tasks/utils/decisionValidation.ts
   Line: 110

   Comment:
   The `hasOppositionVotes` guard was not updated alongside the new vote types. A "κατά πλειοψηφία" decision where all non-FOR participants declared DID_NOT_VOTE (Αποχή) or PRESENT (Παρών) — valid under the new vote model — will still trip this check and emit a spurious `NO_VOTE_DETAILS` warning, because neither `DID_NOT_VOTE` nor `PRESENT` is counted as "opposition". This was the exact type of non-participation that the new vote types were introduced to represent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/types.ts:432
The vote union here is duplicated inline rather than importing `VoteValue` from `decisionPdfExtraction.ts`. This PR correctly kept both in sync, but `effectiveAttendance.ts` and `decisionValidation.ts` both import `VoteValue` — the same pattern here would make future extensions (adding a new vote type) a single-site change.

```suggestion
    voteDetails: { personId: string; vote: import('./tasks/utils/decisionPdfExtraction.js').VoteValue }[];
```

### Issue 2 of 2
src/tasks/utils/extractionPipeline.ts:165-177
**`unmatchedInitialAttendance` is not deduplicated**

If the LLM returns the same name in both `presentMembers` and `absentMembers` of `firstWithRoll` (an LLM data anomaly), the unmatched name would appear twice in `unmatchedInitialAttendance`, and the same `personId` would appear twice in `initialAttendance` with conflicting statuses. A `new Set()` pass on `unmatchedInitialAttendance` (and a duplicate-`personId` guard on `initialAttendance`) would make the output contract cleaner for consumers.


`````

</details>

<sub>Reviews (8): Last reviewed commit: ["chore: add pollDecisions task version an..."](https://github.com/schemalabz/opencouncil-tasks/commit/6c1d249a653853d2de76c260057814f9d698d927) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31162311)</sub>

<!-- /greptile_comment -->