### PR TITLE
fix: normalize video audio loudness to -14 LUFS

### DIFF
--- a/src/tasks/downloadYTV.test.ts
+++ b/src/tasks/downloadYTV.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getVideoIdAndUrl, formatBytes } from './downloadYTV.js';
+import { getVideoIdAndUrl, formatBytes, parseLoudnormStats } from './downloadYTV.js';
 
 describe('getVideoIdAndUrl', () => {
   it('extracts ID from youtube.com/watch?v=...', () => {
@@ -58,5 +58,51 @@ describe('formatBytes', () => {
 
   it('formats gigabytes', () => {
     expect(formatBytes(1073741824)).toBe('1 GB');
+  });
+});
+
+describe('parseLoudnormStats', () => {
+  const sampleStderr = `
+Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'input.mp4':
+  Duration: 01:23:45.67, start: 0.000000
+Stream mapping:
+  Stream #0:1 -> #0:0 (aac (native) -> pcm_s16le (native))
+[Parsed_loudnorm_0 @ 0x5555555]
+{
+	"input_i" : "-27.10",
+	"input_tp" : "-8.34",
+	"input_lra" : "14.20",
+	"input_thresh" : "-37.65",
+	"output_i" : "-14.02",
+	"output_tp" : "-1.50",
+	"output_lra" : "11.00",
+	"output_thresh" : "-24.57",
+	"normalization_type" : "dynamic",
+	"target_offset" : "0.02"
+}
+size=N/A time=01:23:45.67 bitrate=N/A speed= 125x
+`;
+
+  it('extracts loudnorm stats from ffmpeg stderr', () => {
+    const stats = parseLoudnormStats(sampleStderr);
+    expect(stats).toEqual({
+      input_i: '-27.10',
+      input_tp: '-8.34',
+      input_lra: '14.20',
+      input_thresh: '-37.65',
+    });
+  });
+
+  it('throws when no JSON block is found', () => {
+    expect(() => parseLoudnormStats('no json here')).toThrow(
+      'Could not find loudnorm JSON',
+    );
+  });
+
+  it('throws when required fields are missing', () => {
+    const incomplete = '{ "input_i" : "-14.0", "input_tp" : "-1.5" }';
+    expect(() => parseLoudnormStats(incomplete)).toThrow(
+      'Missing loudnorm field',
+    );
   });
 });

--- a/src/tasks/downloadYTV.ts
+++ b/src/tasks/downloadYTV.ts
@@ -62,6 +62,7 @@ export const downloadYTV: Task<string, { audioOnly: string, combined: string, so
     }
 
     console.log(`Video downloaded successfully: ${formatBytes(videoSize)}`);
+    await normalizeVideoAudio(finalVideoPath);
     await extractSoundFromMP4(finalVideoPath, audioOutputPath);
 
     return { audioOnly: audioOutputPath, combined: finalVideoPath, sourceType };
@@ -99,6 +100,93 @@ export const getVideoIdAndUrl = (mediaUrl: string) => {
 
     return { videoId: randomId(), videoUrl: mediaUrl, sourceType: 'Direct URL' };
 }
+type LoudnormStats = {
+    input_i: string;
+    input_tp: string;
+    input_lra: string;
+    input_thresh: string;
+};
+
+const LOUDNORM_TARGET = { I: -14, TP: -1.5, LRA: 11 };
+const AUDIO_BITRATE = '128k';
+
+export function parseLoudnormStats(stderr: string): LoudnormStats {
+    // ffmpeg's loudnorm filter outputs a JSON block at the end of stderr
+    const jsonMatch = stderr.match(/\{[^{}]*"input_i"\s*:\s*"[^"]*"[^{}]*\}/s);
+    if (!jsonMatch) {
+        throw new Error('Could not find loudnorm JSON in ffmpeg output');
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]);
+    const required = ['input_i', 'input_tp', 'input_lra', 'input_thresh'] as const;
+    for (const key of required) {
+        if (typeof parsed[key] !== 'string') {
+            throw new Error(`Missing loudnorm field: ${key}`);
+        }
+    }
+
+    return {
+        input_i: parsed.input_i,
+        input_tp: parsed.input_tp,
+        input_lra: parsed.input_lra,
+        input_thresh: parsed.input_thresh,
+    };
+}
+
+function runFfmpeg(args: string[]): Promise<{ stderr: string }> {
+    const ffmpegBin = ffmpegPath();
+    return new Promise((resolve, reject) => {
+        const proc = cp.spawn(ffmpegBin, args, {
+            windowsHide: true,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+
+        let stderr = '';
+        proc.stderr.on('data', (data) => { stderr += data.toString(); });
+
+        proc.on('close', (code) => {
+            if (code === 0) resolve({ stderr });
+            else reject(new Error(`FFmpeg exited with code ${code}: ${stderr.slice(-500)}`));
+        });
+        proc.on('error', reject);
+    });
+}
+
+async function normalizeVideoAudio(filePath: string): Promise<void> {
+    const { I, TP, LRA } = LOUDNORM_TARGET;
+    const loudnormFilter = `loudnorm=I=${I}:TP=${TP}:LRA=${LRA}`;
+    const filename = path.basename(filePath);
+
+    // Pass 1: measure loudness
+    const pass1Start = Date.now();
+    const { stderr } = await runFfmpeg([
+        '-i', filePath,
+        '-af', `${loudnormFilter}:print_format=json`,
+        '-f', 'null', '-',
+    ]);
+    const pass1Duration = ((Date.now() - pass1Start) / 1000).toFixed(1);
+
+    const stats = parseLoudnormStats(stderr);
+    const deltaI = (I - parseFloat(stats.input_i)).toFixed(1);
+    console.log(`[loudnorm] ${filename}: I=${stats.input_i} LUFS (target ${I}, Δ${parseFloat(deltaI) >= 0 ? '+' : ''}${deltaI}) | TP=${stats.input_tp} dBTP (ceiling ${TP}) | LRA=${stats.input_lra} (target ${LRA}) | thresh=${stats.input_thresh} | measure=${pass1Duration}s`);
+
+    // Pass 2: apply normalization with linear mode
+    const tempPath = filePath + '.normalized.mp4';
+    const pass2Start = Date.now();
+    await runFfmpeg([
+        '-i', filePath,
+        '-c:v', 'copy',
+        '-af', `${loudnormFilter}:measured_I=${stats.input_i}:measured_TP=${stats.input_tp}:measured_LRA=${stats.input_lra}:measured_thresh=${stats.input_thresh}:linear=true`,
+        '-c:a', 'aac', '-b:a', AUDIO_BITRATE,
+        '-y', tempPath,
+    ]);
+    const pass2Duration = ((Date.now() - pass2Start) / 1000).toFixed(1);
+
+    // Replace original with normalized version
+    fs.renameSync(tempPath, filePath);
+    console.log(`[loudnorm] ${filename}: normalize=${pass2Duration}s, total=${((Date.now() - pass1Start) / 1000).toFixed(1)}s`);
+}
+
 const FREQUENCY_FILTER = true;
 const extractSoundFromMP4 = async (inputPath: string, outputPath: string): Promise<void> => {
     // Validate input file exists and is not empty


### PR DESCRIPTION
## Summary

- Add two-pass ffmpeg `loudnorm` normalization to the video's audio track after download, before Mux/Spaces upload
- Pass 1 measures integrated loudness, pass 2 applies linear gain targeting -14 LUFS (EBU R128) — avoids pumping artifacts from single-pass dynamic normalization
- Video stream is copied as-is (`-c:v copy`), only audio is re-encoded to 128k AAC

## Context

Some YouTube source recordings are significantly quieter than the -14 LUFS standard. YouTube normalizes playback volume, but our pipeline passes the raw MP4 to Mux unchanged, so quiet recordings sound noticeably lower on OpenCouncil. See investigation and measurements in #28.

Closes #28

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (298 tests, including new `parseLoudnormStats` unit tests)
- [x] Manual test: downloaded `8e4AEoE0mOI` (-24.48 LUFS source) → normalized to -14 LUFS

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two-pass EBU R128 loudness normalization (`loudnorm` filter) to the video download pipeline, re-encoding only the audio track to 128 kbps AAC while stream-copying the video, targeting -14 LUFS to match YouTube's playback normalization level.

- **Two-pass normalization**: Pass 1 measures integrated loudness via `ffmpeg -f null`; pass 2 applies a linear gain using the measured stats, avoiding dynamic-compression artifacts.
- **`parseLoudnormStats`**: A new exported helper parses the JSON block from ffmpeg's stderr; it is well-tested with unit tests covering the happy path, missing JSON, and incomplete fields.
- **Known open issues** (flagged in prior review threads): normalization runs unconditionally on cached files causing re-encoding on every retry, and the intermediate `tempPath` file is not cleaned up if pass 2 throws.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge; the normalization logic is correct, but unconditional re-normalization of cached files and orphaned temp files on pass-2 failure remain unaddressed.

The two-pass ffmpeg implementation is correct and the unit tests are solid. Two open issues from prior review threads remain unaddressed: unconditional normalization of cached files silently degrades audio quality across retries, and missing cleanup of the temp file on pass-2 failure can leave multi-GB partial files accumulating on disk.

src/tasks/downloadYTV.ts — specifically the normalizeVideoAudio call site (line 65) and the missing try/finally around the temp file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/tasks/downloadYTV.ts | Adds two-pass loudnorm normalization; normalizeVideoAudio is called unconditionally on every run (including cached files), and the temp file is not cleaned up on pass-2 failure — both flagged in prior review threads. |
| src/tasks/downloadYTV.test.ts | Adds targeted unit tests for parseLoudnormStats; covers happy path, missing JSON block, and missing required fields. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downloadYTV called] --> B{Video file exists & non-empty?}
    B -- Yes --> C[Use cached file]
    B -- No --> D{sourceType?}
    D -- YouTube + COBALT --> E[getCobaltStreamUrl + downloadUrl]
    D -- YouTube + yt-dlp --> F[downloadWithYtDlp]
    D -- Direct URL --> G[downloadUrl]
    E & F & G --> H[Validate file size > 0]
    C --> I[normalizeVideoAudio]
    H --> I
    I --> J[Pass 1: ffmpeg loudnorm measure]
    J --> K[parseLoudnormStats]
    K --> L[Pass 2: ffmpeg loudnorm linear gain]
    L --> M{Pass 2 success?}
    M -- Yes --> N[renameSync tempPath to filePath]
    M -- No --> O[tempPath orphaned on disk]
    N --> P[extractSoundFromMP4]
    P --> Q[Return audioOnly + combined paths]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/tasks/downloadYTV.ts:103-108
The `target_offset` returned by pass 1 (the small correction needed to hit exactly -14 LUFS) is not forwarded to pass 2 as `offset`. Without it, the applied gain is calculated from `measured_I` vs `I` alone, and the actual output loudness can land a fraction of a dB away from the target. In the test's sample the drift would be 0.02 dB — imperceptible — but for videos with a higher `target_offset` it grows. The `LoudnormStats` type and `parseLoudnormStats` should also capture this field and forward it to the pass 2 filter string.

```suggestion
type LoudnormStats = {
    input_i: string;
    input_tp: string;
    input_lra: string;
    input_thresh: string;
    target_offset: string;
};
```

### Issue 2 of 3
src/tasks/downloadYTV.ts:121-133
The `required` array and return statement should also include `target_offset` so it is extracted from the pass-1 JSON and available for the pass-2 filter.

```suggestion
    const required = ['input_i', 'input_tp', 'input_lra', 'input_thresh', 'target_offset'] as const;
    for (const key of required) {
        if (typeof parsed[key] !== 'string') {
            throw new Error(`Missing loudnorm field: ${key}`);
        }
    }

    return {
        input_i: parsed.input_i,
        input_tp: parsed.input_tp,
        input_lra: parsed.input_lra,
        input_thresh: parsed.input_thresh,
        target_offset: parsed.target_offset,
    };
```

### Issue 3 of 3
src/tasks/downloadYTV.ts:179
And the pass-2 filter string should include `offset=${stats.target_offset}` to apply the full EBU R128 two-pass correction.

```suggestion
        '-af', `${loudnormFilter}:measured_I=${stats.input_i}:measured_TP=${stats.input_tp}:measured_LRA=${stats.input_lra}:measured_thresh=${stats.input_thresh}:offset=${stats.target_offset}:linear=true`,
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: normalize video audio loudness to -..."](https://github.com/schemalabz/opencouncil-tasks/commit/ecf35e258e613d51d2c019e0654d56582731cc0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31598133)</sub>

<!-- /greptile_comment -->