### PR TITLE
feat: effective attendance computation for all subjects + arrivals/departures

### DIFF
--- a/src/tasks/pollDecisions.test.ts
+++ b/src/tasks/pollDecisions.test.ts
@@ -27,7 +27,7 @@ vi.mock("../lib/ai.js", () => ({
 
 // Mock extractionPipeline (extraction is tested separately)
 vi.mock("./utils/extractionPipeline.js", () => ({
-    extractDecisionsFromPdfs: vi.fn(async () => ({ decisions: [], warnings: [], usage: NO_USAGE_MOCK, initialAttendance: [], unmatchedInitialAttendance: [], meetingAttendanceData: null })),
+    extractDecisionsFromPdfs: vi.fn(async () => ({ decisions: [], warnings: [], usage: NO_USAGE_MOCK, initialAttendance: [], unmatchedInitialAttendance: [], nonDecisionSubjectAttendance: [] })),
 }));
 
 import { aiChat } from "../lib/ai.js";
@@ -401,7 +401,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
-            meetingAttendanceData: null,
+            nonDecisionSubjectAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -452,7 +452,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
-            meetingAttendanceData: null,
+            nonDecisionSubjectAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -501,7 +501,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
-            meetingAttendanceData: null,
+            nonDecisionSubjectAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -545,7 +545,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
-            meetingAttendanceData: null,
+            nonDecisionSubjectAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -588,7 +588,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
-            meetingAttendanceData: null,
+            nonDecisionSubjectAttendance: [],
         });
 
         const result = await pollDecisions(
@@ -642,7 +642,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
-            meetingAttendanceData: null,
+            nonDecisionSubjectAttendance: [],
         });
 
         const result = await pollDecisions(

--- a/src/tasks/pollDecisions.test.ts
+++ b/src/tasks/pollDecisions.test.ts
@@ -27,7 +27,7 @@ vi.mock("../lib/ai.js", () => ({
 
 // Mock extractionPipeline (extraction is tested separately)
 vi.mock("./utils/extractionPipeline.js", () => ({
-    extractDecisionsFromPdfs: vi.fn(async () => ({ decisions: [], warnings: [], usage: NO_USAGE_MOCK, initialAttendance: [], unmatchedInitialAttendance: [] })),
+    extractDecisionsFromPdfs: vi.fn(async () => ({ decisions: [], warnings: [], usage: NO_USAGE_MOCK, initialAttendance: [], unmatchedInitialAttendance: [], meetingAttendanceData: null })),
 }));
 
 import { aiChat } from "../lib/ai.js";
@@ -401,6 +401,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
+            meetingAttendanceData: null,
         });
 
         const result = await pollDecisions(
@@ -451,6 +452,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
+            meetingAttendanceData: null,
         });
 
         const result = await pollDecisions(
@@ -499,6 +501,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
+            meetingAttendanceData: null,
         });
 
         const result = await pollDecisions(
@@ -542,6 +545,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
+            meetingAttendanceData: null,
         });
 
         const result = await pollDecisions(
@@ -584,6 +588,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
+            meetingAttendanceData: null,
         });
 
         const result = await pollDecisions(
@@ -637,6 +642,7 @@ describe("pollDecisions - verification", () => {
             usage: noUsage,
             initialAttendance: [],
             unmatchedInitialAttendance: [],
+            meetingAttendanceData: null,
         });
 
         const result = await pollDecisions(

--- a/src/tasks/pollDecisions.ts
+++ b/src/tasks/pollDecisions.ts
@@ -5,7 +5,6 @@ import { PollDecisionsRequest, PollDecisionsResult, ExtractedDecisionResult } fr
 import { Task } from "./pipeline.js";
 import { aiChat, addUsage, NO_USAGE, HAIKU_MODEL } from "../lib/ai.js";
 import { extractDecisionsFromPdfs, ExtractionSubject } from "./utils/extractionPipeline.js";
-import { computeAllSubjectAttendance } from "./utils/meetingAttendance.js";
 
 /**
  * Remove a match and its extraction from the results, moving the subject to unmatched.
@@ -597,8 +596,23 @@ export const pollDecisions: Task<PollDecisionsRequest, PollDecisionsResult> = as
         onProgress("extracting PDFs", 50);
         console.log(`\nExtracting ${allExtractionSubjects.length} decision PDFs (${extractionSubjects.length} new, ${needsExtractionSubjects.length} re-extraction)...`);
 
+        // Build subject list for meeting-level attendance computation.
+        // The pipeline uses this to compute effective attendance for ALL subjects
+        // (including those without decisions) using the complete discussion order.
+        let oaCounter = 0;
+        const allMeetingSubjects = request.subjects.map(s => {
+            const isOA = s.nonAgendaReason === 'outOfAgenda';
+            if (isOA) oaCounter++;
+            return {
+                subjectId: s.subjectId,
+                agendaItemIndex: s.agendaItemIndex,
+                outOfAgendaIndex: isOA ? oaCounter : null,
+            };
+        });
+
         const pipelineResult = await extractDecisionsFromPdfs(
             allExtractionSubjects,
+            allMeetingSubjects,
             request.people,
             (stage, percent) => {
                 // Map extraction progress (0-100) to overall progress (50-85)
@@ -731,58 +745,12 @@ export const pollDecisions: Task<PollDecisionsRequest, PollDecisionsResult> = as
             }
         }
 
-        // --- Compute effective attendance using complete discussion order ---
-        // The per-PDF computation only sees agenda items mentioned in that PDF.
-        // Here we use the aggregated meeting-level data (all attendance changes,
-        // complete discussion order) for consistent results across all subjects.
-        let nonDecisionSubjectAttendance: NonNullable<PollDecisionsResult['extractions']>['nonDecisionSubjectAttendance'] = [];
-
-        if (pipelineResult.meetingAttendanceData) {
-            // Assign sequential OA indices (1-based) from request order.
-            // The request includes nonAgendaReason so we can identify OA subjects
-            // and assign their position without depending on extraction results.
-            let oaCounter = 0;
-            const subjectsForAttendance = request.subjects.map(s => {
-                const isOA = s.nonAgendaReason === 'outOfAgenda';
-                if (isOA) oaCounter++;
-                return {
-                    subjectId: s.subjectId,
-                    agendaItemIndex: s.agendaItemIndex,
-                    outOfAgendaIndex: isOA ? oaCounter : null,
-                };
-            });
-
-            const allAttendance = computeAllSubjectAttendance(
-                subjectsForAttendance,
-                pipelineResult.meetingAttendanceData,
-            );
-
-            // Build lookup for quick access
-            const attendanceBySubject = new Map(allAttendance.map(a => [a.subjectId, a]));
-
-            // Overwrite per-decision attendance with meeting-level values
-            const decisionSubjectIds = new Set<string>();
-            for (const decision of pipelineResult.decisions) {
-                decisionSubjectIds.add(decision.subjectId);
-                const meetingLevel = attendanceBySubject.get(decision.subjectId);
-                if (meetingLevel) {
-                    decision.presentMemberIds = meetingLevel.presentMemberIds;
-                    decision.absentMemberIds = meetingLevel.absentMemberIds;
-                }
-            }
-
-            // Collect attendance for subjects without decisions
-            nonDecisionSubjectAttendance = allAttendance.filter(a => !decisionSubjectIds.has(a.subjectId));
-
-            console.log(`Computed effective attendance: ${pipelineResult.decisions.length} decision subjects updated, ${nonDecisionSubjectAttendance.length} non-decision subjects added`);
-        }
-
         extractionResult = {
             decisions: pipelineResult.decisions,
             warnings: pipelineResult.warnings,
             initialAttendance: pipelineResult.initialAttendance,
             unmatchedInitialAttendance: pipelineResult.unmatchedInitialAttendance,
-            nonDecisionSubjectAttendance,
+            nonDecisionSubjectAttendance: pipelineResult.nonDecisionSubjectAttendance,
         };
     } else if (allExtractionSubjects.length > 0 && (!request.people || request.people.length === 0)) {
         console.log(`Skipping extraction: no people provided for name matching`);

--- a/src/tasks/pollDecisions.ts
+++ b/src/tasks/pollDecisions.ts
@@ -5,6 +5,7 @@ import { PollDecisionsRequest, PollDecisionsResult, ExtractedDecisionResult } fr
 import { Task } from "./pipeline.js";
 import { aiChat, addUsage, NO_USAGE, HAIKU_MODEL } from "../lib/ai.js";
 import { extractDecisionsFromPdfs, ExtractionSubject } from "./utils/extractionPipeline.js";
+import { computeAllSubjectAttendance } from "./utils/meetingAttendance.js";
 
 /**
  * Remove a match and its extraction from the results, moving the subject to unmatched.
@@ -730,11 +731,47 @@ export const pollDecisions: Task<PollDecisionsRequest, PollDecisionsResult> = as
             }
         }
 
+        // --- Compute effective attendance using complete discussion order ---
+        // The per-PDF computation only sees agenda items mentioned in that PDF.
+        // Here we use the aggregated meeting-level data (all attendance changes,
+        // complete discussion order) for consistent results across all subjects.
+        let nonDecisionSubjectAttendance: NonNullable<PollDecisionsResult['extractions']>['nonDecisionSubjectAttendance'] = [];
+
+        if (pipelineResult.meetingAttendanceData) {
+            const allAttendance = computeAllSubjectAttendance(
+                request.subjects.map(s => ({
+                    subjectId: s.subjectId,
+                    agendaItemIndex: s.agendaItemIndex,
+                })),
+                pipelineResult.meetingAttendanceData,
+            );
+
+            // Build lookup for quick access
+            const attendanceBySubject = new Map(allAttendance.map(a => [a.subjectId, a]));
+
+            // Overwrite per-decision attendance with meeting-level values
+            const decisionSubjectIds = new Set<string>();
+            for (const decision of pipelineResult.decisions) {
+                decisionSubjectIds.add(decision.subjectId);
+                const meetingLevel = attendanceBySubject.get(decision.subjectId);
+                if (meetingLevel) {
+                    decision.presentMemberIds = meetingLevel.presentMemberIds;
+                    decision.absentMemberIds = meetingLevel.absentMemberIds;
+                }
+            }
+
+            // Collect attendance for subjects without decisions
+            nonDecisionSubjectAttendance = allAttendance.filter(a => !decisionSubjectIds.has(a.subjectId));
+
+            console.log(`Computed effective attendance: ${pipelineResult.decisions.length} decision subjects updated, ${nonDecisionSubjectAttendance.length} non-decision subjects added`);
+        }
+
         extractionResult = {
             decisions: pipelineResult.decisions,
             warnings: pipelineResult.warnings,
             initialAttendance: pipelineResult.initialAttendance,
             unmatchedInitialAttendance: pipelineResult.unmatchedInitialAttendance,
+            nonDecisionSubjectAttendance,
         };
     } else if (allExtractionSubjects.length > 0 && (!request.people || request.people.length === 0)) {
         console.log(`Skipping extraction: no people provided for name matching`);

--- a/src/tasks/pollDecisions.ts
+++ b/src/tasks/pollDecisions.ts
@@ -738,11 +738,22 @@ export const pollDecisions: Task<PollDecisionsRequest, PollDecisionsResult> = as
         let nonDecisionSubjectAttendance: NonNullable<PollDecisionsResult['extractions']>['nonDecisionSubjectAttendance'] = [];
 
         if (pipelineResult.meetingAttendanceData) {
-            const allAttendance = computeAllSubjectAttendance(
-                request.subjects.map(s => ({
+            // Assign sequential OA indices (1-based) from request order.
+            // The request includes nonAgendaReason so we can identify OA subjects
+            // and assign their position without depending on extraction results.
+            let oaCounter = 0;
+            const subjectsForAttendance = request.subjects.map(s => {
+                const isOA = s.nonAgendaReason === 'outOfAgenda';
+                if (isOA) oaCounter++;
+                return {
                     subjectId: s.subjectId,
                     agendaItemIndex: s.agendaItemIndex,
-                })),
+                    outOfAgendaIndex: isOA ? oaCounter : null,
+                };
+            });
+
+            const allAttendance = computeAllSubjectAttendance(
+                subjectsForAttendance,
                 pipelineResult.meetingAttendanceData,
             );
 

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -255,10 +255,10 @@ Extract the following information from the PDF:
      - "nonAgendaReason": "outOfAgenda" if the item is explicitly an out-of-agenda/emergency item (ΕΚΤΑΚΤΟ ΘΕΜΑ, ΘΕΜΑ ΕΚΤΟΣ Η.Δ.), otherwise null
      Set "agendaItem" to null if no specific item is mentioned (person arrived at session start or left at session end).
    - "timing": The temporal relationship to the agenda item:
-     - "during" if the change happened DURING the item discussion (e.g., "κατά τη διάρκεια του 9ου θέματος", "κατά τη συζήτηση του 3ου θέματος")
-     - "after" if the change happened AFTER the item ended (e.g., "μετά τη λήξη της συζήτησης του 9ου θέματος", "μετά το 5ο θέμα")
+     - "during" if the change happened DURING or BEFORE the item discussion (e.g., "κατά τη διάρκεια του 9ου θέματος", "κατά τη συζήτηση του 3ου θέματος", "πριν τη συζήτηση του 1ου θέματος", "πριν το 4ο θέμα"). Use "during" for BOTH "κατά" and "πριν" — both mean the person was absent from that item onward.
+     - "after" if the change happened AFTER the item ENDED (e.g., "μετά τη λήξη της συζήτησης του 9ου θέματος", "μετά το 5ο θέμα"). Use "after" ONLY for "μετά" — it means the person was present and voted on that item, then left.
      Set to null when "agendaItem" is null (session-level changes).
-     The distinction matters: "after item 9" means the person was present and voted on item 9, while "during item 9" means they left/arrived partway through.
+     The distinction matters: "after item 9" means the person was present for item 9, while "during item 9" or "before item 9" means they were absent from item 9 onward.
    - "rawText": the original sentence describing this change.
    If no such section exists, return an empty array.
 11. **discussionOrder**: When subjects were discussed out of the standard agenda order (e.g. "Προτάθηκε η αλλαγή σειράς συζήτησης", items reordered, or out-of-agenda items inserted between regular items), extract the full discussion sequence including both regular and out-of-agenda/emergency items. Each entry is an object with:
@@ -441,6 +441,7 @@ Names may differ in:
 - Word order or missing middle names
 - Accents/diacritics (monotonic vs polytonic, missing accents)
 - Hyphenation or spacing (e.g. "ΚΩΝΣΤΑΝΤΙΝΑ - ΟΛΥΜΠΙΑ" vs "Κωνσταντίνα-Ολυμπία")
+- First-initial abbreviations (e.g., "Ε. Χριστούλη" → "ΕΛΕΝΗ ΧΡΙΣΤΟΥΛΗ", "Κ. Αγγελής" → "ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ"). Match by surname — if the surname is unique among available people, the initial is enough.
 - Greek diminutives (υποκοριστικά): official documents use formal/legal names while databases often store the commonly used form. These can be very different from the formal name. Examples: Παρασκευή→Βούλα/Εύη, Ελπινίκη→Νίκη, Κωνσταντίνα→Τάνια/Ντίνα, Κωνσταντίνος→Ντίνος/Κώστας, Ευαγγελία→Εύα/Λίτσα, Δημήτριος→Μήτσος/Τάκης, Γεώργιος→Γιώργος, Αθανάσιος→Θανάσης, Χαράλαμπος→Μπάμπης
 
 **Key strategy**: When the surname matches exactly between an unmatched name and only ONE available person shares that surname, the first name is very likely a diminutive — match them even if the first name looks very different. If multiple available people share the same surname, only match when you can confidently identify the diminutive.

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -302,6 +302,7 @@ If a field cannot be found, use empty array for lists, empty string for text, an
 export function normalizeGreekName(name: string): string {
     return name
         .replace(/\s*\([^)]*\)\s*/g, ' ')      // strip parenthetical nicknames
+        .replace(/[\u2010-\u2015\u2212]/g, ' ')  // normalize Unicode dashes (en-dash, em-dash, etc.) to spaces; preserve ASCII hyphen-minus in compound surnames
         .normalize('NFD')                        // decompose accented chars
         .replace(/[\u0300-\u036f]/g, '')         // strip combining diacriticals (tonos etc.)
         .toLowerCase()

--- a/src/tasks/utils/effectiveAttendance.test.ts
+++ b/src/tasks/utils/effectiveAttendance.test.ts
@@ -352,6 +352,66 @@ describe('computeEffectiveAttendance', () => {
         }).presentNames).not.toContain('Bob');
     });
 
+    it('matches names with en-dash vs space differences (normalizes dashes)', () => {
+        // Real-world case: composition uses space, attendance change uses en-dash
+        const input = {
+            initialPresent: ['ΣΤΡΑΚΑΝΤΟΥΝΑ ΣΦΑΚΑΚΗ ΒΑΣΙΛΙΚΗ', 'ΠΑΠΑΔΟΠΟΥΛΟΣ ΙΩΑΝΝΗΣ'],
+            initialAbsent: [],
+            allAgendaItemNumbers: [ref(1), ref(2), ref(3), ref(9), ref(10)],
+            discussionOrder: [ref(1), ref(9), ref(10)],
+            attendanceChanges: [
+                makeChange({
+                    name: 'ΣΤΡΑΚΑΝΤΟΥΝΑ \u2013ΣΦΑΚΑΚΗ ΒΑΣΙΛΙΚΗ', // en-dash instead of space
+                    type: 'departure',
+                    agendaItem: ref(9),
+                    timing: 'after',
+                }),
+            ],
+        };
+
+        // At subject #9, she's still present (departure is AFTER #9)
+        const at9 = computeEffectiveAttendance({
+            ...input,
+            targetAgendaItemNumber: ref(9),
+        });
+        expect(at9.presentNames).toContain('ΣΤΡΑΚΑΝΤΟΥΝΑ ΣΦΑΚΑΚΗ ΒΑΣΙΛΙΚΗ');
+
+        // At subject #10, she should be absent
+        const at10 = computeEffectiveAttendance({
+            ...input,
+            targetAgendaItemNumber: ref(10),
+        });
+        expect(at10.presentNames).not.toContain('ΣΤΡΑΚΑΝΤΟΥΝΑ ΣΦΑΚΑΚΗ ΒΑΣΙΛΙΚΗ');
+        expect(at10.absentNames).toContain('ΣΤΡΑΚΑΝΤΟΥΝΑ ΣΦΑΚΑΚΗ ΒΑΣΙΛΙΚΗ');
+        // Total count should be preserved (no phantom entries)
+        expect(at10.presentNames.length + at10.absentNames.length).toBe(2);
+    });
+
+    it('matches names with diacritics/case differences', () => {
+        const input = {
+            initialPresent: ['Παπαδόπουλος Ιωάννης', 'Μαρία Κωνσταντίνου'],
+            initialAbsent: [],
+            allAgendaItemNumbers: [ref(1), ref(2), ref(3)],
+            discussionOrder: null,
+            attendanceChanges: [
+                makeChange({
+                    name: 'ΠΑΠΑΔΟΠΟΥΛΟΣ ΙΩΑΝΝΗΣ', // uppercase, no accents
+                    type: 'departure',
+                    agendaItem: ref(2),
+                    timing: 'during',
+                }),
+            ],
+        };
+
+        const at3 = computeEffectiveAttendance({
+            ...input,
+            targetAgendaItemNumber: ref(3),
+        });
+        // Should use canonical (first-seen) form
+        expect(at3.presentNames).not.toContain('Παπαδόπουλος Ιωάννης');
+        expect(at3.absentNames).toContain('Παπαδόπουλος Ιωάννης');
+    });
+
     it('handles after-departure with out-of-agenda items in mixed sequence', () => {
         const changes = [
             makeChange({ name: 'Bob', type: 'departure', agendaItem: ref(1, 'outOfAgenda'), timing: 'after' }),

--- a/src/tasks/utils/effectiveAttendance.ts
+++ b/src/tasks/utils/effectiveAttendance.ts
@@ -1,4 +1,4 @@
-import { AttendanceChange, AgendaItemRef, RawExtractedDecision, VoteValue, inferForVotes } from './decisionPdfExtraction.js';
+import { AttendanceChange, AgendaItemRef, RawExtractedDecision, VoteValue, inferForVotes, normalizeGreekName } from './decisionPdfExtraction.js';
 
 function agendaItemRefEquals(a: AgendaItemRef, b: AgendaItemRef): boolean {
     return a.agendaItemIndex === b.agendaItemIndex && a.nonAgendaReason === b.nonAgendaReason;
@@ -52,23 +52,44 @@ export function computeEffectiveAttendance(input: EffectiveAttendanceInput): {
 
     const targetIndex = discussionSequence.findIndex(item => agendaItemRefEquals(item, targetAgendaItemNumber));
 
-    // Start with initial attendance
-    const present = new Set(initialPresent);
-    const absent = new Set(initialAbsent);
+    // Use normalized names as keys in the Sets so that minor name
+    // variations (dashes, diacritics, whitespace) don't prevent matching.
+    // Track canonical (first-seen) form for each normalized key.
+    const canonicalName = new Map<string, string>();
+    const registerName = (name: string): string => {
+        const key = normalizeGreekName(name);
+        if (!canonicalName.has(key)) canonicalName.set(key, name);
+        return key;
+    };
+
+    // Start with initial attendance (normalized keys)
+    const present = new Set(initialPresent.map(registerName));
+    const absent = new Set(initialAbsent.map(registerName));
+
+    // Helper: apply an attendance change using normalized matching
+    const applyChange = (change: AttendanceChange) => {
+        const key = registerName(change.name);
+        if (change.type === 'arrival') {
+            absent.delete(key);
+            present.add(key);
+        } else {
+            present.delete(key);
+            absent.add(key);
+        }
+    };
 
     // Apply session-start arrivals immediately (agendaItem: null, type: arrival)
     for (const change of attendanceChanges) {
         if (change.agendaItem === null && change.type === 'arrival') {
-            absent.delete(change.name);
-            present.add(change.name);
+            applyChange(change);
         }
     }
 
     // If target not found in sequence, return current state
     if (targetIndex === -1) {
         return {
-            presentNames: [...present],
-            absentNames: [...absent],
+            presentNames: [...present].map(k => canonicalName.get(k)!),
+            absentNames: [...absent].map(k => canonicalName.get(k)!),
         };
     }
 
@@ -86,13 +107,7 @@ export function computeEffectiveAttendance(input: EffectiveAttendanceInput): {
                     change.timing === 'after' &&
                     agendaItemRefEquals(change.agendaItem, previousItem)
                 ) {
-                    if (change.type === 'arrival') {
-                        absent.delete(change.name);
-                        present.add(change.name);
-                    } else {
-                        present.delete(change.name);
-                        absent.add(change.name);
-                    }
+                    applyChange(change);
                 }
             }
         }
@@ -104,20 +119,14 @@ export function computeEffectiveAttendance(input: EffectiveAttendanceInput): {
                 change.timing === 'during' &&
                 agendaItemRefEquals(change.agendaItem, currentItem)
             ) {
-                if (change.type === 'arrival') {
-                    absent.delete(change.name);
-                    present.add(change.name);
-                } else {
-                    present.delete(change.name);
-                    absent.add(change.name);
-                }
+                applyChange(change);
             }
         }
     }
 
     return {
-        presentNames: [...present],
-        absentNames: [...absent],
+        presentNames: [...present].map(k => canonicalName.get(k)!),
+        absentNames: [...absent].map(k => canonicalName.get(k)!),
     };
 }
 

--- a/src/tasks/utils/effectiveAttendance.ts
+++ b/src/tasks/utils/effectiveAttendance.ts
@@ -143,8 +143,7 @@ export interface ProcessedExtraction {
  * Process a raw PDF extraction: compute effective attendance at the target
  * subject, then infer votes using the effective present list.
  *
- * Used by both the extraction pipeline (batch processing) and the CLI
- * (single-PDF testing) to ensure consistent logic.
+ * Used by the CLI for single-PDF testing.
  *
  * @param fallbackAgendaItemIndex - Used when the PDF doesn't contain subjectInfo
  *   but the caller knows the agenda item index (e.g. from the database).

--- a/src/tasks/utils/extractionPipeline.test.ts
+++ b/src/tasks/utils/extractionPipeline.test.ts
@@ -89,7 +89,7 @@ describe('extractDecisionsFromPdfs — warning propagation', () => {
             fromCache: false,
         });
 
-        const result = await extractDecisionsFromPdfs([makeSubject()], people, noopProgress);
+        const result = await extractDecisionsFromPdfs([makeSubject()], [{ subjectId: 'sub-1', agendaItemIndex: 1 }], people, noopProgress);
 
         expect(result.decisions).toHaveLength(1);
         const codes = result.decisions[0].warnings.map(w => w.code);
@@ -103,7 +103,7 @@ describe('extractDecisionsFromPdfs — warning propagation', () => {
             fromCache: false,
         });
 
-        const result = await extractDecisionsFromPdfs([makeSubject()], people, noopProgress);
+        const result = await extractDecisionsFromPdfs([makeSubject()], [{ subjectId: 'sub-1', agendaItemIndex: 1 }], people, noopProgress);
 
         const codes = result.decisions[0].warnings.map(w => w.code);
         expect(codes).toContain('EXTRACTION_INCOMPLETE');
@@ -119,7 +119,7 @@ describe('extractDecisionsFromPdfs — warning propagation', () => {
             fromCache: false,
         });
 
-        const result = await extractDecisionsFromPdfs([makeSubject()], people, noopProgress);
+        const result = await extractDecisionsFromPdfs([makeSubject()], [{ subjectId: 'sub-1', agendaItemIndex: 1 }], people, noopProgress);
 
         const codes = result.decisions[0].warnings.map(w => w.code);
         expect(codes).toContain('NO_VOTE_DETAILS');
@@ -132,7 +132,7 @@ describe('extractDecisionsFromPdfs — warning propagation', () => {
             fromCache: false,
         });
 
-        const result = await extractDecisionsFromPdfs([makeSubject()], people, noopProgress);
+        const result = await extractDecisionsFromPdfs([makeSubject()], [{ subjectId: 'sub-1', agendaItemIndex: 1 }], people, noopProgress);
 
         // Only INFERRED_VOTES expected (unanimous with no explicit votes)
         const codes = result.decisions[0].warnings.map(w => w.code);
@@ -165,7 +165,7 @@ describe('extractDecisionsFromPdfs — warning propagation', () => {
             usage: noUsage,
         });
 
-        const result = await extractDecisionsFromPdfs([makeSubject()], people, noopProgress);
+        const result = await extractDecisionsFromPdfs([makeSubject()], [{ subjectId: 'sub-1', agendaItemIndex: 1 }], people, noopProgress);
 
         const decision = result.decisions[0];
         const p1Votes = decision.voteDetails.filter(v => v.personId === 'p1');
@@ -195,7 +195,7 @@ describe('extractDecisionsFromPdfs — warning propagation', () => {
             usage: noUsage,
         });
 
-        await extractDecisionsFromPdfs([makeSubject()], people, noopProgress);
+        await extractDecisionsFromPdfs([makeSubject()], [{ subjectId: 'sub-1', agendaItemIndex: 1 }], people, noopProgress);
 
         expect(mockLlmMatchMembers).toHaveBeenCalledWith(
             ['Unknown Name'],
@@ -216,7 +216,7 @@ describe('extractDecisionsFromPdfs — warning propagation', () => {
             fromCache: false,
         });
 
-        const result = await extractDecisionsFromPdfs([makeSubject()], people, noopProgress);
+        const result = await extractDecisionsFromPdfs([makeSubject()], [{ subjectId: 'sub-1', agendaItemIndex: 1 }], people, noopProgress);
 
         const codes = result.decisions[0].warnings.map(w => w.code);
         // Raw-level warning

--- a/src/tasks/utils/extractionPipeline.ts
+++ b/src/tasks/utils/extractionPipeline.ts
@@ -254,11 +254,25 @@ export async function extractDecisionsFromPdfs(
     // --- Phase 3: Compute meeting-level attendance for all subjects ---
     // Uses the aggregated attendance data (resolved names, complete discussion order)
     // to compute effective attendance consistently for every subject.
+    //
+    // Assign OA indices from extraction subjectInfo (the PDF knows the actual OA
+    // number) rather than counting in request order (which depends on DB ordering).
+    const oaIndexFromExtraction = new Map<string, number>();
+    for (const { subjectId, raw } of extractions) {
+        if (raw.subjectInfo?.nonAgendaReason === 'outOfAgenda') {
+            oaIndexFromExtraction.set(subjectId, raw.subjectInfo.agendaItemIndex);
+        }
+    }
+    const subjectsWithOAIndices: SubjectForAttendance[] = allMeetingSubjects.map(s => ({
+        ...s,
+        outOfAgendaIndex: oaIndexFromExtraction.get(s.subjectId) ?? s.outOfAgendaIndex ?? null,
+    }));
+
     const attendanceBySubject = new Map<string, { presentMemberIds: string[]; absentMemberIds: string[] }>();
     let nonDecisionSubjectAttendance: ExtractionPipelineResult['nonDecisionSubjectAttendance'] = [];
 
     if (meetingAttendanceData) {
-        const allAttendance = computeAllSubjectAttendance(allMeetingSubjects, meetingAttendanceData);
+        const allAttendance = computeAllSubjectAttendance(subjectsWithOAIndices, meetingAttendanceData);
         for (const a of allAttendance) {
             attendanceBySubject.set(a.subjectId, { presentMemberIds: a.presentMemberIds, absentMemberIds: a.absentMemberIds });
         }

--- a/src/tasks/utils/extractionPipeline.ts
+++ b/src/tasks/utils/extractionPipeline.ts
@@ -11,6 +11,7 @@ import {
     AgendaItemRef,
 } from './decisionPdfExtraction.js';
 import { processRawExtraction } from './effectiveAttendance.js';
+import { resolveAndDeduplicateAttendanceChanges } from './meetingAttendance.js';
 import { validateRawExtraction, validateProcessedDecision } from './decisionValidation.js';
 
 export interface ExtractionSubject {
@@ -173,23 +174,12 @@ export async function extractDecisionsFromPdfs(
     const firstWithRoll = extractions.find(e => (e.raw.presentMembers?.length ?? 0) > 0 || (e.raw.absentMembers?.length ?? 0) > 0);
 
     // --- Aggregate meeting-level attendance data from all PDFs ---
-    // All PDFs from the same meeting share the same preamble (composition, attendance
-    // changes, discussion order). We aggregate from all PDFs to get the most complete
-    // picture, deduplicating attendance changes by rawText.
+    // All PDFs from the same meeting share the same attendance preamble.
+    // See resolveAndDeduplicateAttendanceChanges for the resolution strategy.
     let meetingAttendanceData: ExtractionPipelineResult['meetingAttendanceData'] = null;
     if (firstWithRoll) {
-        // Deduplicate attendance changes by rawText + name + type (same change appears in every PDF)
-        const changesSeen = new Set<string>();
-        const aggregatedChanges: AttendanceChange[] = [];
-        for (const { raw } of extractions) {
-            for (const change of raw.attendanceChanges || []) {
-                const key = `${change.name}|${change.type}|${change.rawText}`;
-                if (!changesSeen.has(key)) {
-                    changesSeen.add(key);
-                    aggregatedChanges.push(change);
-                }
-            }
-        }
+        const allInitialNames = [...(firstWithRoll.raw.presentMembers || []), ...(firstWithRoll.raw.absentMembers || [])];
+        const aggregatedChanges = resolveAndDeduplicateAttendanceChanges(extractions, nameToPersonId, allInitialNames);
 
         // Use the longest discussion order from any PDF (most complete)
         let bestDiscussionOrder: AgendaItemRef[] | null = null;
@@ -206,6 +196,19 @@ export async function extractDecisionsFromPdfs(
             discussionOrder: bestDiscussionOrder,
             nameToPersonId,
         };
+
+        // Log attendance changes after resolution
+        if (aggregatedChanges.length > 0) {
+            console.log(`  Attendance changes (${aggregatedChanges.length} after resolution/dedup):`);
+            for (const change of aggregatedChanges) {
+                const personId = nameToPersonId.get(change.name);
+                const status = personId ? '✓' : '✗ unmatched';
+                const agendaLabel = change.agendaItem
+                    ? `${change.timing} ${change.agendaItem.nonAgendaReason === 'outOfAgenda' ? 'OA' : '#'}${change.agendaItem.agendaItemIndex}`
+                    : 'session';
+                console.log(`    ${change.type} "${change.name}" ${agendaLabel} ${status}`);
+            }
+        }
     }
 
     // --- Build meeting-level initial attendance from the first extraction with roll call data ---

--- a/src/tasks/utils/extractionPipeline.ts
+++ b/src/tasks/utils/extractionPipeline.ts
@@ -7,6 +7,8 @@ import {
     matchPersonByName,
     llmMatchMembers,
     PersonForMatching,
+    AttendanceChange,
+    AgendaItemRef,
 } from './decisionPdfExtraction.js';
 import { processRawExtraction } from './effectiveAttendance.js';
 import { validateRawExtraction, validateProcessedDecision } from './decisionValidation.js';
@@ -30,6 +32,14 @@ export interface ExtractionPipelineResult {
     initialAttendance: { personId: string; status: 'PRESENT' | 'ABSENT' }[];
     /** Names from the initial roll call that couldn't be matched to any person in the database */
     unmatchedInitialAttendance: string[];
+    /** Meeting-level raw attendance data aggregated from all PDFs, for computing effective attendance of any subject */
+    meetingAttendanceData: {
+        initialPresent: string[];
+        initialAbsent: string[];
+        attendanceChanges: AttendanceChange[];
+        discussionOrder: AgendaItemRef[] | null;
+        nameToPersonId: Map<string, string>;
+    } | null;
 }
 
 const BATCH_SIZE = 5;
@@ -62,7 +72,7 @@ export async function extractDecisionsFromPdfs(
     if (mayorName) console.log(`Mayor: ${mayorName} (${mayorId})`);
 
     if (subjects.length === 0) {
-        return { decisions: [], warnings: [], usage: totalUsage, initialAttendance: [], unmatchedInitialAttendance: [] };
+        return { decisions: [], warnings: [], usage: totalUsage, initialAttendance: [], unmatchedInitialAttendance: [], meetingAttendanceData: null };
     }
 
     // --- Phase 1: Extract all PDFs (batched for concurrency) ---
@@ -160,10 +170,47 @@ export async function extractDecisionsFromPdfs(
 
     console.log(`  Final matched: ${nameToPersonId.size}/${allRawNames.size}`);
 
+    const firstWithRoll = extractions.find(e => (e.raw.presentMembers?.length ?? 0) > 0 || (e.raw.absentMembers?.length ?? 0) > 0);
+
+    // --- Aggregate meeting-level attendance data from all PDFs ---
+    // All PDFs from the same meeting share the same preamble (composition, attendance
+    // changes, discussion order). We aggregate from all PDFs to get the most complete
+    // picture, deduplicating attendance changes by rawText.
+    let meetingAttendanceData: ExtractionPipelineResult['meetingAttendanceData'] = null;
+    if (firstWithRoll) {
+        // Deduplicate attendance changes by rawText + name + type (same change appears in every PDF)
+        const changesSeen = new Set<string>();
+        const aggregatedChanges: AttendanceChange[] = [];
+        for (const { raw } of extractions) {
+            for (const change of raw.attendanceChanges || []) {
+                const key = `${change.name}|${change.type}|${change.rawText}`;
+                if (!changesSeen.has(key)) {
+                    changesSeen.add(key);
+                    aggregatedChanges.push(change);
+                }
+            }
+        }
+
+        // Use the longest discussion order from any PDF (most complete)
+        let bestDiscussionOrder: AgendaItemRef[] | null = null;
+        for (const { raw } of extractions) {
+            if (raw.discussionOrder && (bestDiscussionOrder === null || raw.discussionOrder.length > bestDiscussionOrder.length)) {
+                bestDiscussionOrder = raw.discussionOrder;
+            }
+        }
+
+        meetingAttendanceData = {
+            initialPresent: firstWithRoll.raw.presentMembers || [],
+            initialAbsent: firstWithRoll.raw.absentMembers || [],
+            attendanceChanges: aggregatedChanges,
+            discussionOrder: bestDiscussionOrder,
+            nameToPersonId,
+        };
+    }
+
     // --- Build meeting-level initial attendance from the first extraction with roll call data ---
     // All PDFs from the same meeting have the same initial roll, so we use the first one.
     const initialAttendance: ExtractionPipelineResult['initialAttendance'] = [];
-    const firstWithRoll = extractions.find(e => (e.raw.presentMembers?.length ?? 0) > 0 || (e.raw.absentMembers?.length ?? 0) > 0);
     const unmatchedInitialAttendance: string[] = [];
     if (firstWithRoll) {
         for (const name of firstWithRoll.raw.presentMembers || []) {
@@ -279,5 +326,5 @@ export async function extractDecisionsFromPdfs(
     console.log(`  Extracted: ${extractions.length}/${subjects.length}`);
     console.log(`  Warnings: ${warnings.length}`);
 
-    return { decisions, warnings, usage: totalUsage, initialAttendance, unmatchedInitialAttendance };
+    return { decisions, warnings, usage: totalUsage, initialAttendance, unmatchedInitialAttendance, meetingAttendanceData };
 }

--- a/src/tasks/utils/extractionPipeline.ts
+++ b/src/tasks/utils/extractionPipeline.ts
@@ -7,11 +7,9 @@ import {
     matchPersonByName,
     llmMatchMembers,
     PersonForMatching,
-    AttendanceChange,
     AgendaItemRef,
 } from './decisionPdfExtraction.js';
-import { processRawExtraction } from './effectiveAttendance.js';
-import { resolveAndDeduplicateAttendanceChanges } from './meetingAttendance.js';
+import { resolveAndDeduplicateAttendanceChanges, computeAllSubjectAttendance, SubjectForAttendance, MeetingAttendanceData } from './meetingAttendance.js';
 import { validateRawExtraction, validateProcessedDecision } from './decisionValidation.js';
 
 export interface ExtractionSubject {
@@ -33,14 +31,12 @@ export interface ExtractionPipelineResult {
     initialAttendance: { personId: string; status: 'PRESENT' | 'ABSENT' }[];
     /** Names from the initial roll call that couldn't be matched to any person in the database */
     unmatchedInitialAttendance: string[];
-    /** Meeting-level raw attendance data aggregated from all PDFs, for computing effective attendance of any subject */
-    meetingAttendanceData: {
-        initialPresent: string[];
-        initialAbsent: string[];
-        attendanceChanges: AttendanceChange[];
-        discussionOrder: AgendaItemRef[] | null;
-        nameToPersonId: Map<string, string>;
-    } | null;
+    /** Per-subject effective attendance for subjects without decisions in the extraction */
+    nonDecisionSubjectAttendance: Array<{
+        subjectId: string;
+        presentMemberIds: string[];
+        absentMemberIds: string[];
+    }>;
 }
 
 const BATCH_SIZE = 5;
@@ -48,12 +44,19 @@ const BATCH_SIZE = 5;
 /**
  * Extract structured decision data from PDFs.
  *
- * Each PDF is self-contained for effective attendance: the agenda item list
- * is derived from the PDF's own attendanceChanges, discussionOrder, and
- * subjectInfo rather than requiring external context.
+ * Attendance and vote inference use meeting-level data: attendance changes
+ * and discussion order are aggregated from all PDFs, names are resolved to
+ * canonical forms, and effective attendance is computed once per subject
+ * using the complete discussion order. Vote inference (FOR votes for
+ * unanimous/majority decisions) uses the meeting-level effective attendance.
+ *
+ * @param subjects - Subjects with linked decisions (have PDF URLs)
+ * @param allMeetingSubjects - ALL subjects in the meeting (for discussion order + non-decision attendance)
+ * @param people - People for name matching
  */
 export async function extractDecisionsFromPdfs(
     subjects: ExtractionSubject[],
+    allMeetingSubjects: SubjectForAttendance[],
     people: PersonForMatching[],
     onProgress: (stage: string, percent: number) => void,
     mayorId?: string,
@@ -73,7 +76,7 @@ export async function extractDecisionsFromPdfs(
     if (mayorName) console.log(`Mayor: ${mayorName} (${mayorId})`);
 
     if (subjects.length === 0) {
-        return { decisions: [], warnings: [], usage: totalUsage, initialAttendance: [], unmatchedInitialAttendance: [], meetingAttendanceData: null };
+        return { decisions: [], warnings: [], usage: totalUsage, initialAttendance: [], unmatchedInitialAttendance: [], nonDecisionSubjectAttendance: [] };
     }
 
     // --- Phase 1: Extract all PDFs (batched for concurrency) ---
@@ -176,7 +179,7 @@ export async function extractDecisionsFromPdfs(
     // --- Aggregate meeting-level attendance data from all PDFs ---
     // All PDFs from the same meeting share the same attendance preamble.
     // See resolveAndDeduplicateAttendanceChanges for the resolution strategy.
-    let meetingAttendanceData: ExtractionPipelineResult['meetingAttendanceData'] = null;
+    let meetingAttendanceData: MeetingAttendanceData | null = null;
     if (firstWithRoll) {
         const allInitialNames = [...(firstWithRoll.raw.presentMembers || []), ...(firstWithRoll.raw.absentMembers || [])];
         const aggregatedChanges = resolveAndDeduplicateAttendanceChanges(extractions, nameToPersonId, allInitialNames);
@@ -248,37 +251,58 @@ export async function extractDecisionsFromPdfs(
         }
     }
 
-    // --- Phase 3: Build decision results using the name→personId map ---
-    // Each PDF is self-contained: build allAgendaItemNumbers from its own data
+    // --- Phase 3: Compute meeting-level attendance for all subjects ---
+    // Uses the aggregated attendance data (resolved names, complete discussion order)
+    // to compute effective attendance consistently for every subject.
+    const attendanceBySubject = new Map<string, { presentMemberIds: string[]; absentMemberIds: string[] }>();
+    let nonDecisionSubjectAttendance: ExtractionPipelineResult['nonDecisionSubjectAttendance'] = [];
+
+    if (meetingAttendanceData) {
+        const allAttendance = computeAllSubjectAttendance(allMeetingSubjects, meetingAttendanceData);
+        for (const a of allAttendance) {
+            attendanceBySubject.set(a.subjectId, { presentMemberIds: a.presentMemberIds, absentMemberIds: a.absentMemberIds });
+        }
+        const decisionSubjectIds = new Set(extractions.map(e => e.subjectId));
+        nonDecisionSubjectAttendance = allAttendance.filter(a => !decisionSubjectIds.has(a.subjectId));
+        console.log(`  Computed attendance for ${allAttendance.length} subjects (${nonDecisionSubjectAttendance.length} without decisions)`);
+    }
+
+    // --- Phase 4: Build decision results ---
+    // Combines raw PDF content (excerpt, explicit votes) with meeting-level
+    // attendance. Vote inference uses the meeting-level present list.
     const decisions: ExtractedDecisionResult[] = [];
 
-    for (const { subjectId, agendaItemIndex, raw, fromCache } of extractions) {
+    for (const { subjectId, raw, fromCache } of extractions) {
         const unmatchedMembers: string[] = [];
 
-        // Compute effective attendance and infer votes
-        const processed = processRawExtraction(raw, agendaItemIndex);
-        if (processed.inferredVoteCount > 0) {
-            console.log(`  [${subjectId}] Inferred ${processed.inferredVoteCount} FOR votes from effective present members`);
+        // Attendance: use meeting-level if available, otherwise raw from PDF
+        const attendance = attendanceBySubject.get(subjectId);
+        let presentMemberIds: string[];
+        let absentMemberIds: string[];
+        if (attendance) {
+            presentMemberIds = attendance.presentMemberIds;
+            absentMemberIds = attendance.absentMemberIds;
+        } else {
+            // Fallback: convert raw names to personIds (no attendance changes applied)
+            presentMemberIds = [];
+            absentMemberIds = [];
+            for (const name of raw.presentMembers || []) {
+                const personId = nameToPersonId.get(name);
+                if (personId) presentMemberIds.push(personId);
+                else unmatchedMembers.push(name);
+            }
+            for (const name of raw.absentMembers || []) {
+                const personId = nameToPersonId.get(name);
+                if (personId) absentMemberIds.push(personId);
+                else unmatchedMembers.push(name);
+            }
         }
 
-        const presentMemberIds: string[] = [];
-        const absentMemberIds: string[] = [];
-
-        for (const name of processed.effectivePresent) {
-            const personId = nameToPersonId.get(name);
-            if (personId) presentMemberIds.push(personId);
-            else unmatchedMembers.push(name);
-        }
-
-        for (const name of processed.effectiveAbsent) {
-            const personId = nameToPersonId.get(name);
-            if (personId) absentMemberIds.push(personId);
-            else unmatchedMembers.push(name);
-        }
-
+        // Explicit votes from PDF (AGAINST, ABSTAIN, PRESENT, DID_NOT_VOTE)
+        // Resolve names to personIds, deduplicate
         const voteDetails: ExtractedDecisionResult['voteDetails'] = [];
         const seenVoterIds = new Set<string>();
-        for (const detail of processed.voteDetails) {
+        for (const detail of raw.voteDetails || []) {
             const personId = nameToPersonId.get(detail.name);
             if (personId) {
                 if (!seenVoterIds.has(personId)) {
@@ -288,6 +312,25 @@ export async function extractDecisionsFromPdfs(
             } else {
                 unmatchedMembers.push(detail.name);
             }
+        }
+
+        // Infer FOR votes for unanimous/majority decisions using meeting-level attendance
+        const isUnanimous = raw.voteResult && /[οό]μ[οό]φων/i.test(raw.voteResult);
+        const isMajority = raw.voteResult && /κατ[άα]\s+πλειοψηφ[ίι]/i.test(raw.voteResult);
+        const hasNoForVotes = voteDetails.every(v => v.vote !== 'FOR');
+
+        let inferredVoteCount = 0;
+        if ((isUnanimous || isMajority) && hasNoForVotes && presentMemberIds.length > 0) {
+            for (const personId of presentMemberIds) {
+                if (!seenVoterIds.has(personId)) {
+                    seenVoterIds.add(personId);
+                    voteDetails.push({ personId, vote: 'FOR' });
+                    inferredVoteCount++;
+                }
+            }
+        }
+        if (inferredVoteCount > 0) {
+            console.log(`  [${subjectId}] Inferred ${inferredVoteCount} FOR votes from effective present members`);
         }
 
         const dedupedUnmatched = [...new Set(unmatchedMembers)];
@@ -329,5 +372,5 @@ export async function extractDecisionsFromPdfs(
     console.log(`  Extracted: ${extractions.length}/${subjects.length}`);
     console.log(`  Warnings: ${warnings.length}`);
 
-    return { decisions, warnings, usage: totalUsage, initialAttendance, unmatchedInitialAttendance, meetingAttendanceData };
+    return { decisions, warnings, usage: totalUsage, initialAttendance, unmatchedInitialAttendance, nonDecisionSubjectAttendance };
 }

--- a/src/tasks/utils/meetingAttendance.test.ts
+++ b/src/tasks/utils/meetingAttendance.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+    computeAllSubjectAttendance,
+    buildCompleteDiscussionOrder,
+    SubjectForAttendance,
+    MeetingAttendanceData,
+} from './meetingAttendance.js';
+import { AgendaItemRef } from './decisionPdfExtraction.js';
+
+function ref(index: number, nonAgendaReason: 'outOfAgenda' | null = null): AgendaItemRef {
+    return { agendaItemIndex: index, nonAgendaReason };
+}
+
+function makeMeetingData(overrides: Partial<MeetingAttendanceData> = {}): MeetingAttendanceData {
+    return {
+        initialPresent: ['Alice', 'Bob', 'Charlie'],
+        initialAbsent: ['Diana'],
+        attendanceChanges: [],
+        discussionOrder: null,
+        nameToPersonId: new Map([
+            ['Alice', 'p1'],
+            ['Bob', 'p2'],
+            ['Charlie', 'p3'],
+            ['Diana', 'p4'],
+        ]),
+        ...overrides,
+    };
+}
+
+describe('buildCompleteDiscussionOrder', () => {
+    it('returns subjects in numerical order when no explicit discussion order', () => {
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 's3', agendaItemIndex: 3 },
+            { subjectId: 's1', agendaItemIndex: 1 },
+            { subjectId: 's2', agendaItemIndex: 2 },
+        ];
+        const result = buildCompleteDiscussionOrder(null, subjects);
+        expect(result).toEqual([ref(1), ref(2), ref(3)]);
+    });
+
+    it('appends remaining subjects after explicit order', () => {
+        const explicitOrder = [ref(1), ref(1, 'outOfAgenda'), ref(9), ref(2, 'outOfAgenda'), ref(3, 'outOfAgenda')];
+        const subjects: SubjectForAttendance[] = Array.from({ length: 12 }, (_, i) => ({
+            subjectId: `s${i + 1}`,
+            agendaItemIndex: i + 1,
+        }));
+
+        const result = buildCompleteDiscussionOrder(explicitOrder, subjects);
+
+        expect(result).toEqual([
+            ref(1), ref(1, 'outOfAgenda'), ref(9), ref(2, 'outOfAgenda'), ref(3, 'outOfAgenda'),
+            ref(2), ref(3), ref(4), ref(5), ref(6), ref(7), ref(8), ref(10), ref(11), ref(12),
+        ]);
+    });
+
+    it('does not duplicate items already in explicit order', () => {
+        const explicitOrder = [ref(3), ref(1), ref(2)];
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 's1', agendaItemIndex: 1 },
+            { subjectId: 's2', agendaItemIndex: 2 },
+            { subjectId: 's3', agendaItemIndex: 3 },
+        ];
+
+        const result = buildCompleteDiscussionOrder(explicitOrder, subjects);
+        expect(result).toEqual([ref(3), ref(1), ref(2)]);
+    });
+
+    it('skips subjects with null agendaItemIndex', () => {
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 's1', agendaItemIndex: 1 },
+            { subjectId: 'soa', agendaItemIndex: null },
+            { subjectId: 's2', agendaItemIndex: 2 },
+        ];
+        const result = buildCompleteDiscussionOrder(null, subjects);
+        expect(result).toEqual([ref(1), ref(2)]);
+    });
+});
+
+describe('computeAllSubjectAttendance', () => {
+    it('returns initial attendance for all subjects when no changes', () => {
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 'sub-1', agendaItemIndex: 1 },
+            { subjectId: 'sub-2', agendaItemIndex: 2 },
+        ];
+
+        const result = computeAllSubjectAttendance(subjects, makeMeetingData());
+        expect(result).toHaveLength(2);
+        for (const entry of result) {
+            expect(entry.presentMemberIds.sort()).toEqual(['p1', 'p2', 'p3']);
+            expect(entry.absentMemberIds).toEqual(['p4']);
+        }
+    });
+
+    it('applies mid-meeting departure correctly across subjects', () => {
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 'sub-1', agendaItemIndex: 1 },
+            { subjectId: 'sub-9', agendaItemIndex: 9 },
+            { subjectId: 'sub-10', agendaItemIndex: 10 },
+        ];
+
+        const result = computeAllSubjectAttendance(subjects, makeMeetingData({
+            attendanceChanges: [{
+                name: 'Bob',
+                type: 'departure',
+                agendaItem: ref(9),
+                timing: 'after',
+                rawText: 'Bob left after item 9',
+            }],
+            discussionOrder: [ref(1), ref(9), ref(10)],
+        }));
+
+        const sub1 = result.find(r => r.subjectId === 'sub-1')!;
+        expect(sub1.presentMemberIds).toContain('p2');
+
+        const sub9 = result.find(r => r.subjectId === 'sub-9')!;
+        expect(sub9.presentMemberIds).toContain('p2');
+
+        const sub10 = result.find(r => r.subjectId === 'sub-10')!;
+        expect(sub10.presentMemberIds).not.toContain('p2');
+        expect(sub10.absentMemberIds).toContain('p2');
+    });
+
+    it('Zografou case: departure after #9 applies to subjects after #9 in complete order', () => {
+        const subjects: SubjectForAttendance[] = Array.from({ length: 12 }, (_, i) => ({
+            subjectId: `sub-${i + 1}`,
+            agendaItemIndex: i + 1,
+        }));
+
+        const result = computeAllSubjectAttendance(subjects, makeMeetingData({
+            attendanceChanges: [{
+                name: 'Bob',
+                type: 'departure',
+                agendaItem: ref(9),
+                timing: 'after',
+                rawText: 'Bob left after item 9',
+            }],
+            discussionOrder: [
+                ref(1), ref(1, 'outOfAgenda'), ref(9),
+                ref(2, 'outOfAgenda'), ref(3, 'outOfAgenda'),
+            ],
+        }));
+
+        expect(result.find(r => r.subjectId === 'sub-1')!.presentMemberIds).toContain('p2');
+        expect(result.find(r => r.subjectId === 'sub-9')!.presentMemberIds).toContain('p2');
+        expect(result.find(r => r.subjectId === 'sub-3')!.presentMemberIds).not.toContain('p2');
+        expect(result.find(r => r.subjectId === 'sub-3')!.absentMemberIds).toContain('p2');
+        expect(result.find(r => r.subjectId === 'sub-10')!.presentMemberIds).not.toContain('p2');
+    });
+
+    it('skips subjects with null agendaItemIndex', () => {
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 'sub-1', agendaItemIndex: 1 },
+            { subjectId: 'sub-oa', agendaItemIndex: null },
+        ];
+
+        const result = computeAllSubjectAttendance(subjects, makeMeetingData());
+        expect(result).toHaveLength(1);
+        expect(result[0].subjectId).toBe('sub-1');
+    });
+
+    it('filters out names with no personId mapping', () => {
+        const data = makeMeetingData({
+            initialPresent: ['Alice', 'UnknownPerson'],
+            nameToPersonId: new Map([['Alice', 'p1']]),
+        });
+
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 'sub-1', agendaItemIndex: 1 },
+        ];
+
+        const result = computeAllSubjectAttendance(subjects, data);
+        expect(result[0].presentMemberIds).toEqual(['p1']);
+        expect(result[0].absentMemberIds).toEqual([]);
+    });
+});

--- a/src/tasks/utils/meetingAttendance.test.ts
+++ b/src/tasks/utils/meetingAttendance.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
+    resolveAndDeduplicateAttendanceChanges,
     computeAllSubjectAttendance,
     buildCompleteDiscussionOrder,
     SubjectForAttendance,
     MeetingAttendanceData,
 } from './meetingAttendance.js';
-import { AgendaItemRef } from './decisionPdfExtraction.js';
+import { AgendaItemRef, AttendanceChange } from './decisionPdfExtraction.js';
 
 function ref(index: number, nonAgendaReason: 'outOfAgenda' | null = null): AgendaItemRef {
     return { agendaItemIndex: index, nonAgendaReason };
@@ -27,15 +28,115 @@ function makeMeetingData(overrides: Partial<MeetingAttendanceData> = {}): Meetin
     };
 }
 
+function makeChange(overrides: Partial<AttendanceChange> & Pick<AttendanceChange, 'name' | 'type'>): AttendanceChange {
+    return { agendaItem: null, timing: null, rawText: '', ...overrides };
+}
+
+describe('resolveAndDeduplicateAttendanceChanges', () => {
+    const nameToPersonId = new Map([
+        ['ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', 'p1'],
+        ['Κ. Αγγελής', 'p1'],
+        ['ΕΛΕΝΗ ΧΡΙΣΤΟΥΛΗ', 'p2'],
+    ]);
+    const initialNames = ['ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', 'ΕΛΕΝΗ ΧΡΙΣΤΟΥΛΗ'];
+
+    it('resolves abbreviated names to canonical initial-list form', () => {
+        const extractions = [{
+            raw: { attendanceChanges: [
+                makeChange({ name: 'Κ. Αγγελής', type: 'departure', agendaItem: ref(1), timing: 'during' }),
+            ] },
+        }];
+
+        const result = resolveAndDeduplicateAttendanceChanges(extractions, nameToPersonId, initialNames);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ');
+        expect(result[0].timing).toBe('during');
+    });
+
+    it('deduplicates same change from multiple PDFs with different name variants', () => {
+        const extractions = [
+            { raw: { attendanceChanges: [
+                makeChange({ name: 'Κ. Αγγελής', type: 'departure', agendaItem: ref(1), timing: 'during' }),
+            ] } },
+            { raw: { attendanceChanges: [
+                makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'during' }),
+            ] } },
+        ];
+
+        const result = resolveAndDeduplicateAttendanceChanges(extractions, nameToPersonId, initialNames);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ');
+    });
+
+    it('picks timing by majority vote', () => {
+        // 3 PDFs say "during", 1 says "after" → "during" wins
+        const extractions = [
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'after' })] } },
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'during' })] } },
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'during' })] } },
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'during' })] } },
+        ];
+
+        const result = resolveAndDeduplicateAttendanceChanges(extractions, nameToPersonId, initialNames);
+        expect(result).toHaveLength(1);
+        expect(result[0].timing).toBe('during');
+    });
+
+    it('prefers specified timing over null on tie', () => {
+        const extractions = [
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: null })] } },
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'during' })] } },
+        ];
+
+        const result = resolveAndDeduplicateAttendanceChanges(extractions, nameToPersonId, initialNames);
+        expect(result).toHaveLength(1);
+        expect(result[0].timing).toBe('during');
+    });
+
+    it('prefers during over after on tie', () => {
+        const extractions = [
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'after' as const })] } },
+            { raw: { attendanceChanges: [makeChange({ name: 'ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ', type: 'departure', agendaItem: ref(1), timing: 'during' as const })] } },
+        ];
+
+        const result = resolveAndDeduplicateAttendanceChanges(extractions, nameToPersonId, initialNames);
+        expect(result).toHaveLength(1);
+        expect(result[0].timing).toBe('during');
+    });
+
+    it('keeps unmatched names as-is', () => {
+        const extractions = [{
+            raw: { attendanceChanges: [
+                makeChange({ name: 'Ε. Χριστούλη', type: 'arrival', agendaItem: ref(2, 'outOfAgenda'), timing: 'during' }),
+            ] },
+        }];
+        // "Ε. Χριστούλη" not in nameToPersonId
+        const result = resolveAndDeduplicateAttendanceChanges(extractions, new Map([['ΕΛΕΝΗ ΧΡΙΣΤΟΥΛΗ', 'p2']]), initialNames);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('Ε. Χριστούλη'); // unchanged
+    });
+});
+
 describe('buildCompleteDiscussionOrder', () => {
-    it('returns subjects in numerical order when no explicit discussion order', () => {
+    it('returns OA first then regular when no explicit discussion order', () => {
         const subjects: SubjectForAttendance[] = [
             { subjectId: 's3', agendaItemIndex: 3 },
             { subjectId: 's1', agendaItemIndex: 1 },
+            { subjectId: 'soa1', agendaItemIndex: null, outOfAgendaIndex: 1 },
             { subjectId: 's2', agendaItemIndex: 2 },
+            { subjectId: 'soa2', agendaItemIndex: null, outOfAgendaIndex: 2 },
         ];
         const result = buildCompleteDiscussionOrder(null, subjects);
-        expect(result).toEqual([ref(1), ref(2), ref(3)]);
+        expect(result).toEqual([ref(1, 'outOfAgenda'), ref(2, 'outOfAgenda'), ref(1), ref(2), ref(3)]);
+    });
+
+    it('returns only regular subjects when no OA subjects and no explicit order', () => {
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 's3', agendaItemIndex: 3 },
+            { subjectId: 's1', agendaItemIndex: 1 },
+        ];
+        const result = buildCompleteDiscussionOrder(null, subjects);
+        expect(result).toEqual([ref(1), ref(3)]);
     });
 
     it('appends remaining subjects after explicit order', () => {
@@ -147,7 +248,7 @@ describe('computeAllSubjectAttendance', () => {
         expect(result.find(r => r.subjectId === 'sub-10')!.presentMemberIds).not.toContain('p2');
     });
 
-    it('skips subjects with null agendaItemIndex', () => {
+    it('skips subjects with null agendaItemIndex and no outOfAgendaIndex', () => {
         const subjects: SubjectForAttendance[] = [
             { subjectId: 'sub-1', agendaItemIndex: 1 },
             { subjectId: 'sub-oa', agendaItemIndex: null },
@@ -156,6 +257,41 @@ describe('computeAllSubjectAttendance', () => {
         const result = computeAllSubjectAttendance(subjects, makeMeetingData());
         expect(result).toHaveLength(1);
         expect(result[0].subjectId).toBe('sub-1');
+    });
+
+    it('includes OA subjects when outOfAgendaIndex is provided', () => {
+        // Discussion order: OA1, OA2, OA3, then regular items 1-3
+        // Bob departs before topic #1 (during #1) → present for OA items, absent for regular
+        const subjects: SubjectForAttendance[] = [
+            { subjectId: 'sub-oa1', agendaItemIndex: null, outOfAgendaIndex: 1 },
+            { subjectId: 'sub-oa2', agendaItemIndex: null, outOfAgendaIndex: 2 },
+            { subjectId: 'sub-1', agendaItemIndex: 1 },
+            { subjectId: 'sub-2', agendaItemIndex: 2 },
+        ];
+
+        const result = computeAllSubjectAttendance(subjects, makeMeetingData({
+            attendanceChanges: [{
+                name: 'Bob',
+                type: 'departure',
+                agendaItem: ref(1),
+                timing: 'during',
+                rawText: 'Bob left before item 1',
+            }],
+            discussionOrder: [
+                ref(1, 'outOfAgenda'), ref(2, 'outOfAgenda'),
+                ref(1), ref(2),
+            ],
+        }));
+
+        expect(result).toHaveLength(4);
+
+        // OA subjects: Bob present
+        expect(result.find(r => r.subjectId === 'sub-oa1')!.presentMemberIds).toContain('p2');
+        expect(result.find(r => r.subjectId === 'sub-oa2')!.presentMemberIds).toContain('p2');
+
+        // Regular subjects: Bob absent (departed during #1)
+        expect(result.find(r => r.subjectId === 'sub-1')!.presentMemberIds).not.toContain('p2');
+        expect(result.find(r => r.subjectId === 'sub-2')!.presentMemberIds).not.toContain('p2');
     });
 
     it('filters out names with no personId mapping', () => {

--- a/src/tasks/utils/meetingAttendance.ts
+++ b/src/tasks/utils/meetingAttendance.ts
@@ -1,0 +1,130 @@
+import { AttendanceChange, AgendaItemRef } from './decisionPdfExtraction.js';
+import { computeEffectiveAttendance } from './effectiveAttendance.js';
+
+export interface MeetingAttendanceData {
+    initialPresent: string[];
+    initialAbsent: string[];
+    attendanceChanges: AttendanceChange[];
+    discussionOrder: AgendaItemRef[] | null;
+    nameToPersonId: Map<string, string>;
+}
+
+export interface SubjectForAttendance {
+    subjectId: string;
+    agendaItemIndex: number | null;
+}
+
+export interface SubjectAttendanceResult {
+    subjectId: string;
+    presentMemberIds: string[];
+    absentMemberIds: string[];
+}
+
+/**
+ * Build a complete discussion order by merging the partial explicit order
+ * (from PDFs) with the full subject list (from the request).
+ *
+ * The PDF's discussionOrder only mentions items discussed out of their
+ * natural sequence (e.g., [1, OA1, 9, OA2, OA3] when #9 was pulled ahead).
+ * Remaining regular subjects follow in numerical order after the last
+ * explicitly ordered item.
+ *
+ * Result: [1, OA1, 9, OA2, OA3, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12]
+ */
+export function buildCompleteDiscussionOrder(
+    explicitOrder: AgendaItemRef[] | null,
+    subjects: SubjectForAttendance[],
+): AgendaItemRef[] {
+    // Collect all regular agenda items from subjects, sorted numerically
+    const regularRefs: AgendaItemRef[] = subjects
+        .filter(s => s.agendaItemIndex != null)
+        .map(s => ({ agendaItemIndex: s.agendaItemIndex!, nonAgendaReason: null }))
+        .sort((a, b) => a.agendaItemIndex - b.agendaItemIndex);
+
+    if (!explicitOrder || explicitOrder.length === 0) {
+        return regularRefs;
+    }
+
+    // Track which regular items are already in the explicit order
+    const inExplicit = new Set(
+        explicitOrder
+            .filter(r => r.nonAgendaReason === null)
+            .map(r => r.agendaItemIndex)
+    );
+
+    // Append remaining regular items in numerical order
+    const remaining = regularRefs.filter(r => !inExplicit.has(r.agendaItemIndex));
+
+    return [...explicitOrder, ...remaining];
+}
+
+/**
+ * Compute effective attendance for every subject in the meeting using
+ * aggregated meeting-level data from all extracted PDFs.
+ *
+ * Builds a complete discussion order by merging the PDF's partial explicit
+ * order with all regular subjects from the request, then computes effective
+ * attendance for each subject using that unified sequence.
+ *
+ * Skips subjects with agendaItemIndex === null (out-of-agenda items
+ * without a known position — their attendance comes from per-PDF
+ * extraction if a decision exists).
+ */
+export function computeAllSubjectAttendance(
+    subjects: SubjectForAttendance[],
+    data: MeetingAttendanceData,
+): SubjectAttendanceResult[] {
+    const results: SubjectAttendanceResult[] = [];
+
+    // Build complete discussion order: explicit order + remaining subjects in numerical order
+    const completeOrder = buildCompleteDiscussionOrder(data.discussionOrder, subjects);
+
+    // Build the complete set of agenda item refs (for allAgendaItemNumbers)
+    const refsSeen = new Set<string>();
+    const allRefs: AgendaItemRef[] = [];
+    const addRef = (ref: AgendaItemRef) => {
+        const key = `${ref.agendaItemIndex}:${ref.nonAgendaReason ?? ''}`;
+        if (!refsSeen.has(key)) {
+            refsSeen.add(key);
+            allRefs.push(ref);
+        }
+    };
+    for (const ref of completeOrder) addRef(ref);
+    for (const change of data.attendanceChanges) {
+        if (change.agendaItem) addRef(change.agendaItem);
+    }
+
+    for (const subject of subjects) {
+        if (subject.agendaItemIndex == null) continue;
+
+        const targetRef: AgendaItemRef = {
+            agendaItemIndex: subject.agendaItemIndex,
+            nonAgendaReason: null,
+        };
+
+        const effective = computeEffectiveAttendance({
+            initialPresent: data.initialPresent,
+            initialAbsent: data.initialAbsent,
+            attendanceChanges: data.attendanceChanges,
+            discussionOrder: completeOrder,
+            allAgendaItemNumbers: allRefs,
+            targetAgendaItemNumber: targetRef,
+        });
+
+        // Convert raw names to personIds
+        const presentMemberIds: string[] = [];
+        const absentMemberIds: string[] = [];
+        for (const name of effective.presentNames) {
+            const id = data.nameToPersonId.get(name);
+            if (id) presentMemberIds.push(id);
+        }
+        for (const name of effective.absentNames) {
+            const id = data.nameToPersonId.get(name);
+            if (id) absentMemberIds.push(id);
+        }
+
+        results.push({ subjectId: subject.subjectId, presentMemberIds, absentMemberIds });
+    }
+
+    return results;
+}

--- a/src/tasks/utils/meetingAttendance.ts
+++ b/src/tasks/utils/meetingAttendance.ts
@@ -1,5 +1,95 @@
-import { AttendanceChange, AgendaItemRef } from './decisionPdfExtraction.js';
+import { AttendanceChange, AgendaItemRef, RawExtractedDecision } from './decisionPdfExtraction.js';
 import { computeEffectiveAttendance } from './effectiveAttendance.js';
+
+/**
+ * Resolve and deduplicate attendance changes from multiple PDF extractions.
+ *
+ * Every decision PDF from a meeting contains the same attendance preamble,
+ * but the LLM may extract it with slight differences:
+ * - Name variants: abbreviated ("Κ. Αγγελής") vs full ("ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ")
+ * - Timing disagreements: "during" vs "after" vs null for the same event
+ * - Different rawText formatting
+ *
+ * This function:
+ * 1. Resolves names to canonical initial-list forms using nameToPersonId
+ * 2. Groups identical changes (same person + type + agendaItem)
+ * 3. Picks timing by majority vote — the most common timing across PDFs wins
+ *
+ * @param extractions - Raw extractions from all PDFs
+ * @param nameToPersonId - Name → personId mapping from the matching phase
+ * @param initialNames - All names from the initial roll call (present + absent)
+ */
+export function resolveAndDeduplicateAttendanceChanges(
+    extractions: Array<{ raw: Pick<RawExtractedDecision, 'attendanceChanges'> }>,
+    nameToPersonId: Map<string, string>,
+    initialNames: string[],
+): AttendanceChange[] {
+    // Build personId → canonical initial-list name mapping
+    const personIdToInitialName = new Map<string, string>();
+    for (const name of initialNames) {
+        const id = nameToPersonId.get(name);
+        if (id && !personIdToInitialName.has(id)) {
+            personIdToInitialName.set(id, name);
+        }
+    }
+
+    // Group changes by resolved identity (person + type + agendaItem),
+    // collecting timing votes from each PDF
+    const groups = new Map<string, {
+        change: AttendanceChange;
+        timingVotes: Map<string, number>; // timing value → count
+    }>();
+
+    for (const { raw } of extractions) {
+        for (const change of raw.attendanceChanges || []) {
+            // Resolve name to canonical initial-list form
+            const personId = nameToPersonId.get(change.name);
+            const canonicalName = personId ? personIdToInitialName.get(personId) : null;
+            const resolvedName = canonicalName ?? change.name;
+
+            // Group key: resolved name + type + agendaItem (ignoring timing)
+            const agendaKey = change.agendaItem
+                ? `${change.agendaItem.agendaItemIndex}:${change.agendaItem.nonAgendaReason ?? ''}`
+                : 'session';
+            const key = `${resolvedName}|${change.type}|${agendaKey}`;
+
+            const group = groups.get(key);
+            const timingKey = change.timing ?? 'null';
+
+            if (!group) {
+                groups.set(key, {
+                    change: { ...change, name: resolvedName },
+                    timingVotes: new Map([[timingKey, 1]]),
+                });
+            } else {
+                // Add timing vote
+                group.timingVotes.set(timingKey, (group.timingVotes.get(timingKey) ?? 0) + 1);
+            }
+        }
+    }
+
+    // Build final list with majority-voted timing
+    const result: AttendanceChange[] = [];
+    for (const { change, timingVotes } of groups.values()) {
+        // Pick timing with most votes; on tie, prefer specified over null
+        let bestTiming: 'during' | 'after' | null = null;
+        let bestCount = 0;
+        for (const [timing, count] of timingVotes) {
+            // Prefer 'during' over 'after' on a tie (conservative: person was absent).
+            // Prefer any non-null timing over null on a tie.
+            const betterThanCurrent =
+                count > bestCount ||
+                (count === bestCount && timing !== 'null' && (bestTiming == null || timing === 'during'));
+            if (betterThanCurrent) {
+                bestTiming = timing === 'null' ? null : timing as 'during' | 'after';
+                bestCount = count;
+            }
+        }
+        result.push({ ...change, timing: bestTiming });
+    }
+
+    return result;
+}
 
 export interface MeetingAttendanceData {
     initialPresent: string[];
@@ -12,6 +102,8 @@ export interface MeetingAttendanceData {
 export interface SubjectForAttendance {
     subjectId: string;
     agendaItemIndex: number | null;
+    /** For out-of-agenda subjects: their sequential OA index (from PDF extraction subjectInfo) */
+    outOfAgendaIndex?: number | null;
 }
 
 export interface SubjectAttendanceResult {
@@ -26,10 +118,12 @@ export interface SubjectAttendanceResult {
  *
  * The PDF's discussionOrder only mentions items discussed out of their
  * natural sequence (e.g., [1, OA1, 9, OA2, OA3] when #9 was pulled ahead).
- * Remaining regular subjects follow in numerical order after the last
- * explicitly ordered item.
+ * Remaining subjects follow in standard order: OA items first (sorted by
+ * outOfAgendaIndex), then regular items (sorted by agendaItemIndex).
  *
- * Result: [1, OA1, 9, OA2, OA3, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12]
+ * Examples:
+ * - No explicit order: [OA1, OA2, OA3, #1, #2, ..., #11]
+ * - Explicit [1, OA1, 9, OA2, OA3]: [1, OA1, 9, OA2, OA3, #2, #3, ..., #8, #10, #11, #12]
  */
 export function buildCompleteDiscussionOrder(
     explicitOrder: AgendaItemRef[] | null,
@@ -41,21 +135,27 @@ export function buildCompleteDiscussionOrder(
         .map(s => ({ agendaItemIndex: s.agendaItemIndex!, nonAgendaReason: null }))
         .sort((a, b) => a.agendaItemIndex - b.agendaItemIndex);
 
+    // Collect all OA items from subjects, sorted by OA index
+    const oaRefs: AgendaItemRef[] = subjects
+        .filter(s => s.outOfAgendaIndex != null)
+        .map(s => ({ agendaItemIndex: s.outOfAgendaIndex!, nonAgendaReason: 'outOfAgenda' as const }))
+        .sort((a, b) => a.agendaItemIndex - b.agendaItemIndex);
+
     if (!explicitOrder || explicitOrder.length === 0) {
-        return regularRefs;
+        // Standard order: OA items first, then regular items
+        return [...oaRefs, ...regularRefs];
     }
 
-    // Track which regular items are already in the explicit order
+    // Track which items are already in the explicit order
     const inExplicit = new Set(
-        explicitOrder
-            .filter(r => r.nonAgendaReason === null)
-            .map(r => r.agendaItemIndex)
+        explicitOrder.map(r => `${r.agendaItemIndex}:${r.nonAgendaReason ?? ''}`)
     );
 
-    // Append remaining regular items in numerical order
-    const remaining = regularRefs.filter(r => !inExplicit.has(r.agendaItemIndex));
+    // Append remaining items not in explicit order: OA first, then regular
+    const remainingOA = oaRefs.filter(r => !inExplicit.has(`${r.agendaItemIndex}:outOfAgenda`));
+    const remainingRegular = regularRefs.filter(r => !inExplicit.has(`${r.agendaItemIndex}:`));
 
-    return [...explicitOrder, ...remaining];
+    return [...explicitOrder, ...remainingOA, ...remainingRegular];
 }
 
 /**
@@ -66,9 +166,9 @@ export function buildCompleteDiscussionOrder(
  * order with all regular subjects from the request, then computes effective
  * attendance for each subject using that unified sequence.
  *
- * Skips subjects with agendaItemIndex === null (out-of-agenda items
- * without a known position — their attendance comes from per-PDF
- * extraction if a decision exists).
+ * Handles both regular subjects (agendaItemIndex set) and out-of-agenda
+ * subjects (agendaItemIndex null, outOfAgendaIndex set from PDF extraction).
+ * Subjects with neither are skipped.
  */
 export function computeAllSubjectAttendance(
     subjects: SubjectForAttendance[],
@@ -78,6 +178,10 @@ export function computeAllSubjectAttendance(
 
     // Build complete discussion order: explicit order + remaining subjects in numerical order
     const completeOrder = buildCompleteDiscussionOrder(data.discussionOrder, subjects);
+
+    const formatRef = (r: AgendaItemRef) => r.nonAgendaReason === 'outOfAgenda' ? `OA${r.agendaItemIndex}` : `#${r.agendaItemIndex}`;
+    console.log(`  Complete discussion order: [${completeOrder.map(formatRef).join(', ')}]`);
+    console.log(`  Explicit order from PDFs: ${data.discussionOrder ? `[${data.discussionOrder.map(formatRef).join(', ')}]` : 'null'}`);
 
     // Build the complete set of agenda item refs (for allAgendaItemNumbers)
     const refsSeen = new Set<string>();
@@ -95,12 +199,15 @@ export function computeAllSubjectAttendance(
     }
 
     for (const subject of subjects) {
-        if (subject.agendaItemIndex == null) continue;
-
-        const targetRef: AgendaItemRef = {
-            agendaItemIndex: subject.agendaItemIndex,
-            nonAgendaReason: null,
-        };
+        // Determine the target ref for this subject
+        let targetRef: AgendaItemRef;
+        if (subject.agendaItemIndex != null) {
+            targetRef = { agendaItemIndex: subject.agendaItemIndex, nonAgendaReason: null };
+        } else if (subject.outOfAgendaIndex != null) {
+            targetRef = { agendaItemIndex: subject.outOfAgendaIndex, nonAgendaReason: 'outOfAgenda' };
+        } else {
+            continue; // no position info — can't compute attendance
+        }
 
         const effective = computeEffectiveAttendance({
             initialPresent: data.initialPresent,

--- a/src/types.ts
+++ b/src/types.ts
@@ -456,6 +456,7 @@ export interface PollDecisionsRequest extends TaskRequest {
         subjectId: string;
         name: string;
         agendaItemIndex: number | null;
+        nonAgendaReason?: string | null;
         existingDecision?: {
             ada: string;
             decisionTitle: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -503,6 +503,12 @@ export interface PollDecisionsResult {
         initialAttendance: { personId: string; status: 'PRESENT' | 'ABSENT' }[];
         /** Names from the initial roll call that couldn't be matched to any person in the database */
         unmatchedInitialAttendance: string[];
+        /** Effective attendance for subjects WITHOUT linked decisions — computed using the complete discussion order and aggregated attendance changes from all PDFs */
+        nonDecisionSubjectAttendance?: Array<{
+            subjectId: string;
+            presentMemberIds: string[];
+            absentMemberIds: string[];
+        }>;
     } | null;
     costs: {
         input_tokens: number;


### PR DESCRIPTION
## Summary

Addresses items `#1`, `#2`, and `#3` from schemalabz/opencouncil#173 (Phase 2 follow-ups).

### Problem

Per-subject attendance was computed per-PDF in isolation — each subject only saw its own PDF's attendance data, discussion order, and name forms. This caused:
- **Name mismatches**: en-dashes vs spaces (`ΣΤΡΑΚΑΝΤΟΥΝΑ –ΣΦΑΚΑΚΗ` vs `ΣΤΡΑΚΑΝΤΟΥΝΑ ΣΦΑΚΑΚΗ`), abbreviated vs full names (`Κ. Αγγελής` vs `ΚΩΝΣΤΑΝΤΙΝΟΣ ΑΓΓΕΛΗΣ`) silently prevented attendance changes from being applied
- **Missing attendance for subjects without decisions**: no PDF = no attendance computation
- **Inconsistent votes**: FOR votes for unanimous decisions were inferred from per-PDF effective attendance, which often fell back to the initial roll call instead of accounting for mid-meeting arrivals/departures
- **Duplicate/conflicting changes**: same attendance change extracted from 20+ PDFs with different name variants and timing values

### Solution

**Single meeting-level computation path** — attendance changes and discussion order are aggregated from all PDFs once, names are resolved to canonical forms, and effective attendance is computed for every subject (regular + out-of-agenda) using the complete discussion order. Vote inference uses this corrected attendance.

Key changes:
- `resolveAndDeduplicateAttendanceChanges`: resolves names via `nameToPersonId`, groups by person+type+agendaItem, picks timing by majority vote across PDFs
- `buildCompleteDiscussionOrder`: merges the PDF's partial explicit order with the full subject list (OA first, then regular in numerical order)
- `computeAllSubjectAttendance`: computes effective attendance for every subject including OA (via `outOfAgendaIndex`)
- Pipeline Phase 3→4 restructure: attendance computed once at meeting level, vote inference uses that attendance directly. The old per-PDF `processRawExtraction` → overwrite pattern is eliminated
- `normalizeGreekName`: handles Unicode dashes; extraction prompt clarifies "πριν" → `timing: "during"` and adds first-initial abbreviation matching

Companion PR: schemalabz/opencouncil#XXX

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces per-PDF isolated attendance computation with a single meeting-level computation path. Attendance changes from all PDFs are aggregated and deduplicated once, names are resolved to canonical forms, and effective attendance is computed for every subject — including those without decision PDFs — using the complete discussion order.

- **`meetingAttendance.ts`** (new): `resolveAndDeduplicateAttendanceChanges` deduplicates attendance changes across PDFs using majority-vote timing and name canonicalization; `buildCompleteDiscussionOrder` merges the PDF's partial explicit order with the full subject list; `computeAllSubjectAttendance` computes per-subject attendance for the entire meeting.
- **`extractionPipeline.ts`**: Phase 3→4 restructure — attendance is computed once at meeting level, vote inference (FOR votes) uses the resolved per-subject attendance directly instead of falling back to the initial roll call; `nonDecisionSubjectAttendance` is exposed in the result for subjects without linked PDFs.
- **`effectiveAttendance.ts`**: Names in `present`/`absent` sets are keyed by `normalizeGreekName` (handling Unicode dashes, diacritics, case) so that minor name variants in attendance changes match the canonical initial-list form.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no incorrect data paths identified; the meeting-level attendance computation is correct and well-tested.

All three core functions have thorough unit tests including real-world edge cases (Zografou ordering, en-dash normalization, name abbreviation). The tie-breaking logic for timing disagreements across PDFs is deterministic and correctly prefers 'during' over 'after' on ties. Vote inference in Phase 4 is semantically equivalent to the retired inferForVotes helper. The only structural limitation is the 'longest wins' heuristic for discussion-order selection, which is mitigated by buildCompleteDiscussionOrder appending any missing subjects.

No files require special attention. extractionPipeline.ts has a minor heuristic limitation in bestDiscussionOrder selection worth revisiting if ordering disagreements across PDFs occur in practice.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/tasks/utils/meetingAttendance.ts | New file implementing meeting-level attendance aggregation. Tie-breaking logic (prefer 'during' over 'after' on equal counts) is correctly implemented. Deduplication key correctly includes name+type+agendaItem. |
| src/tasks/utils/extractionPipeline.ts | Pipeline restructured from per-PDF to meeting-level attendance. Vote inference logic replicated inline correctly matches the semantics of the retired inferForVotes helper. |
| src/tasks/utils/effectiveAttendance.ts | Name normalization via canonicalName map correctly preserves first-seen (initial-list) form as canonical. Early-return on empty attendanceChanges bypasses normalization but returns raw initial-list names, which are valid keys in nameToPersonId. |
| src/tasks/utils/meetingAttendance.test.ts | Good test coverage of deduplication, majority-vote timing, tie-breaking, complete discussion order construction, and the real-world Zografou case. |
| src/tasks/pollDecisions.ts | OA counter assignment is a reasonable fallback, correctly overridden per-subject by oaIndexFromExtraction when a PDF is available. |
| src/tasks/utils/decisionPdfExtraction.ts | Unicode dash normalization range is correct and intentionally excludes ASCII hyphen-minus to preserve compound surnames. |
| src/types.ts | nonAgendaReason added as optional string | null. nonDecisionSubjectAttendance correctly typed as optional array. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractDecisionsFromPdfs] --> B[Phase 1: Extract all PDFs in batches]
    B --> C[Phase 2: Meeting-level name matching\ntokenSort + LLM fallback → nameToPersonId]
    C --> D[resolveAndDeduplicateAttendanceChanges\nname canonicalization + majority-vote timing]
    C --> E[Select bestDiscussionOrder\nlongest from any PDF]
    D --> F[MeetingAttendanceData]
    E --> F
    F --> G[Phase 3: computeAllSubjectAttendance\nbuildCompleteDiscussionOrder]
    G --> H[computeEffectiveAttendance per subject\nnormalized name keys → personId lookup]
    H --> I[attendanceBySubject Map\n+ nonDecisionSubjectAttendance]
    I --> J[Phase 4: Build decision results\nexplicit votes + inferred FOR votes]
    J --> K[ExtractionPipelineResult]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/tasks/utils/extractionPipeline.ts:187-193
When two or more PDFs each have a `discussionOrder` of the same maximum length, this picks whichever appears first in the `extractions` array rather than the most informative one. More importantly, if PDF-A reports `[1, OA1, 9]` and PDF-B reports `[OA2, 2, 3]` (different items, same length), the selected order omits the items unique to the non-selected PDF entirely. `buildCompleteDiscussionOrder` will still append the missing subjects, but they'll be appended in sorted order rather than at their true meeting position. Merging unique items from all PDFs' discussion orders before passing to `buildCompleteDiscussionOrder` would be more robust.

```suggestion
        // Use the longest discussion order from any PDF (most complete).
        // When two PDFs have the same length but different items, the first
        // one wins; consider merging unique items across all PDFs if this
        // becomes a problem in practice.
        let bestDiscussionOrder: AgendaItemRef[] | null = null;
        for (const { raw } of extractions) {
            if (raw.discussionOrder && (bestDiscussionOrder === null || raw.discussionOrder.length > bestDiscussionOrder.length)) {
                bestDiscussionOrder = raw.discussionOrder;
            }
        }
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: assign OA indices from extraction s..."](https://github.com/schemalabz/opencouncil-tasks/commit/dcb4287888bc38d0117d9b0657e5f5b46ba2613f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32536514)</sub>

<!-- /greptile_comment -->