### PR TITLE
perf(split): use input seeking and stream copy when splitting audio

### DIFF
--- a/src/tasks/splitAudioDiarization.test.ts
+++ b/src/tasks/splitAudioDiarization.test.ts
@@ -13,10 +13,17 @@ describe("buildFfmpegSplitArgs", () => {
         expect(args).toEqual(["-y", "-ss", "3000.500", "-t", "60.250", "-i", "/in.mp3", "-c:a", "copy", "/out.mp3"]);
     });
 
-    it("stream-copies instead of re-encoding", () => {
+    it("stream-copies mp3 input instead of re-encoding", () => {
         const args = buildFfmpegSplitArgs("/in.mp3", "/out.mp3", 0, 60);
 
         expect(args.join(" ")).toContain("-c:a copy");
         expect(args.join(" ")).not.toContain("libmp3lame");
+    });
+
+    it("re-encodes non-mp3 input, which cannot be stream-copied into an mp3 container", () => {
+        const args = buildFfmpegSplitArgs("/in.wav", "/out.mp3", 0, 60);
+
+        expect(args.join(" ")).toContain("-acodec libmp3lame");
+        expect(args.join(" ")).not.toContain("copy");
     });
 });

--- a/src/tasks/splitAudioDiarization.test.ts
+++ b/src/tasks/splitAudioDiarization.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { buildFfmpegSplitArgs } from "./splitAudioDiarization.js";
+
+// These properties are invisible at runtime: ffmpeg produces identical output
+// with -ss after -i or with re-encoding, just orders of magnitude slower on
+// long files. A test is the only guard against silently reverting them.
+describe("buildFfmpegSplitArgs", () => {
+    it("places -ss/-t before -i so ffmpeg seeks instead of decoding from the start", () => {
+        const args = buildFfmpegSplitArgs("/in.mp3", "/out.mp3", 3000.5, 60.25);
+
+        expect(args.indexOf("-ss")).toBeLessThan(args.indexOf("-i"));
+        expect(args.indexOf("-t")).toBeLessThan(args.indexOf("-i"));
+        expect(args).toEqual(["-y", "-ss", "3000.500", "-t", "60.250", "-i", "/in.mp3", "-c:a", "copy", "/out.mp3"]);
+    });
+
+    it("stream-copies instead of re-encoding", () => {
+        const args = buildFfmpegSplitArgs("/in.mp3", "/out.mp3", 0, 60);
+
+        expect(args.join(" ")).toContain("-c:a copy");
+        expect(args.join(" ")).not.toContain("libmp3lame");
+    });
+});

--- a/src/tasks/splitAudioDiarization.ts
+++ b/src/tasks/splitAudioDiarization.ts
@@ -163,9 +163,15 @@ export const buildFfmpegSplitArgs = (input: string, output: string, startTime?: 
 
     args.push('-i', input);
 
-    // The input is already mp3 (produced by downloadYTV), so stream-copy
-    // instead of re-encoding; cuts align to mp3 frame boundaries (~26ms)
-    args.push('-c:a', 'copy');
+    // Pipeline input is always mp3 (produced by downloadYTV), so stream-copy
+    // instead of re-encoding; cuts align to mp3 frame boundaries (~26ms).
+    // Anything else (ad-hoc CLI inputs) can't be muxed into an mp3 container,
+    // so keep the old re-encode path for those.
+    if (path.extname(input).toLowerCase() === '.mp3') {
+        args.push('-c:a', 'copy');
+    } else {
+        args.push('-acodec', 'libmp3lame', '-b:a', '128k');
+    }
 
     args.push(output);
 

--- a/src/tasks/splitAudioDiarization.ts
+++ b/src/tasks/splitAudioDiarization.ts
@@ -150,6 +150,28 @@ export const splitAudioDiarization: Task<SplitAudioArgs, AudioSegment[]> = async
     return audioSegments;
 };
 
+export const buildFfmpegSplitArgs = (input: string, output: string, startTime?: number, duration?: number): string[] => {
+    const args = [
+        '-y'  // Overwrite output file if it exists
+    ];
+
+    // -ss/-t before -i: seek directly to the offset instead of decoding
+    // from the start of the file (an output-side -ss decodes and discards
+    // everything before the seek point, which is quadratic across segments)
+    if (startTime !== undefined) args.push('-ss', startTime.toFixed(3));
+    if (duration !== undefined) args.push('-t', duration.toFixed(3));
+
+    args.push('-i', input);
+
+    // The input is already mp3 (produced by downloadYTV), so stream-copy
+    // instead of re-encoding; cuts align to mp3 frame boundaries (~26ms)
+    args.push('-c:a', 'copy');
+
+    args.push(output);
+
+    return args;
+};
+
 // Helper function to promisify ffmpeg operations
 const ffmpegPromise = (input: string, output: string, startTime?: number, duration?: number): Promise<void> => {
     return new Promise((resolve, reject) => {
@@ -157,23 +179,7 @@ const ffmpegPromise = (input: string, output: string, startTime?: number, durati
         const absoluteInput = path.resolve(input);
         const absoluteOutput = path.resolve(output);
 
-        const args = [
-            '-y'  // Overwrite output file if it exists
-        ];
-
-        // -ss/-t before -i: seek directly to the offset instead of decoding
-        // from the start of the file (an output-side -ss decodes and discards
-        // everything before the seek point, which is quadratic across segments)
-        if (startTime !== undefined) args.push('-ss', startTime.toFixed(3));
-        if (duration !== undefined) args.push('-t', duration.toFixed(3));
-
-        args.push('-i', absoluteInput);
-
-        // The input is already mp3 (produced by downloadYTV), so stream-copy
-        // instead of re-encoding; cuts align to mp3 frame boundaries (~26ms)
-        args.push('-c:a', 'copy');
-
-        args.push(absoluteOutput);
+        const args = buildFfmpegSplitArgs(absoluteInput, absoluteOutput, startTime, duration);
 
         const ffmpegBin = ffmpegPath();
         console.log(`Executing ffmpeg command: ${ffmpegBin} ${args.join(' ')}`);

--- a/src/tasks/splitAudioDiarization.ts
+++ b/src/tasks/splitAudioDiarization.ts
@@ -158,15 +158,20 @@ const ffmpegPromise = (input: string, output: string, startTime?: number, durati
         const absoluteOutput = path.resolve(output);
 
         const args = [
-            '-i', absoluteInput,
             '-y'  // Overwrite output file if it exists
         ];
 
+        // -ss/-t before -i: seek directly to the offset instead of decoding
+        // from the start of the file (an output-side -ss decodes and discards
+        // everything before the seek point, which is quadratic across segments)
         if (startTime !== undefined) args.push('-ss', startTime.toFixed(3));
         if (duration !== undefined) args.push('-t', duration.toFixed(3));
 
-        // Add some ffmpeg optimizations
-        args.push('-acodec', 'libmp3lame', '-b:a', '128k');
+        args.push('-i', absoluteInput);
+
+        // The input is already mp3 (produced by downloadYTV), so stream-copy
+        // instead of re-encoding; cuts align to mp3 frame boundaries (~26ms)
+        args.push('-c:a', 'copy');
 
         args.push(absoluteOutput);
 


### PR DESCRIPTION
## Problem

`splitAudioDiarization` builds its ffmpeg command with `-ss` **after** `-i`, which makes it an output option: ffmpeg decodes the file from the very beginning and discards everything before the seek point. Splitting a 6h43m meeting into 36 segments therefore decoded ~120 hours of audio in total (segment 36 alone decodes 6.5h to reach its start) — about 20 minutes of wall time, observed on staging while testing #43. Each segment was also fully re-encoded with libmp3lame even though the source is already an mp3.

## Fix

- Move `-ss`/`-t` before `-i` so ffmpeg seeks directly to the offset (linear instead of quadratic work).
- Use `-c:a copy` instead of re-encoding — the input is always an mp3 produced by `downloadYTV`, so the split becomes I/O-bound. Cuts align to mp3 frame boundaries (~26ms), which is irrelevant for transcription.

The whole 36-segment split should now take seconds instead of ~20 minutes.

## Testing

- `npm run typecheck` and `npm test` (384 tests) pass.
- Sanity-checked the new argument order with the bundled ffmpeg-static binary: cutting `-ss 30.500 -t 10.250` from a 60s mp3 with `-c:a copy` yields a 10.27s segment (exact within mp3 frame granularity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to ffmpeg argument ordering and copy-vs-encode; transcription pipeline already expects mp3 segments and tolerates minor frame-boundary alignment.
> 
> **Overview**
> **Speeds up diarization-based audio splitting** by changing how `ffmpegPromise` builds ffmpeg invocations in `splitAudioDiarization`.
> 
> `-ss` and `-t` are now placed **before** `-i` so ffmpeg seeks at the input instead of decoding from the start and discarding audio—avoiding quadratic decode work when many late segments are cut from a long file. Re-encoding via `libmp3lame` is replaced with **`-c:a copy`**, since segments are cut from mp3 sources from `downloadYTV`; splits may align to ~26ms mp3 frame boundaries, which is acceptable for downstream transcription.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e441aec9f0e0526a167299d25f6aaa0e820a03d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a quadratic-time ffmpeg decode bug in `splitAudioDiarization` by moving `-ss`/`-t` before `-i` (input-side seeking) and replacing `libmp3lame` re-encoding with `-c:a copy` for mp3 sources.

- `buildFfmpegSplitArgs` is extracted into a testable, exported function that places seek options before `-i` and selects stream-copy vs re-encode based on file extension.
- A new test suite verifies argument ordering, the stream-copy path, and the re-encode fallback for non-mp3 inputs.
- The prior concern about a missing codec guard is addressed: `path.extname(input).toLowerCase() === '.mp3'` gates the copy path and falls back to `libmp3lame` for any other format.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure performance optimization with correct fallback behavior and good test coverage.

The argument reordering and codec switch are correct, the previously flagged codec-guard concern is now addressed via an extension check, and all three relevant code paths are covered by new unit tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/tasks/splitAudioDiarization.ts | Extracts buildFfmpegSplitArgs helper; moves -ss/-t before -i for input-side seeking; uses -c:a copy for mp3 inputs with a file-extension guard that falls back to libmp3lame re-encode for anything else. |
| src/tasks/splitAudioDiarization.test.ts | New test file covering argument order, stream-copy path for mp3, and re-encode fallback for non-mp3 inputs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep re-encode fallback for non-mp3..."](https://github.com/schemalabz/opencouncil-tasks/commit/31cc1d3b65f6a92f9e82f59d337dbe276afa79f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36815623)</sub>

<!-- /greptile_comment -->