### PR TITLE
fix: migrate decision extraction off retiring Sonnet 4 and off assistant prefill

### DIFF
--- a/src/tasks/utils/decisionPdfExtraction.test.ts
+++ b/src/tasks/utils/decisionPdfExtraction.test.ts
@@ -233,10 +233,12 @@ describe('llmMatchMembers', () => {
 
     it('returns LLM-matched names with personIds and usage', async () => {
         mockAiChat.mockResolvedValueOnce({
-            result: JSON.stringify([
-                { name: 'ΣΤΡΑΚΑΝΤΟΥΝΑ ΣΦΑΚΑΚΗ ΒΑΣΙΛΙΚΗ', personId: 'p1' },
-                { name: 'ΑΓΝΩΣΤΟΣ', personId: null },
-            ]),
+            result: {
+                matches: [
+                    { name: 'ΣΤΡΑΚΑΝΤΟΥΝΑ ΣΦΑΚΑΚΗ ΒΑΣΙΛΙΚΗ', personId: 'p1' },
+                    { name: 'ΑΓΝΩΣΤΟΣ', personId: null },
+                ],
+            },
             usage: { input_tokens: 50, output_tokens: 25 },
         });
 
@@ -267,10 +269,12 @@ describe('llmMatchMembers', () => {
 
     it('prevents duplicate personId matches', async () => {
         mockAiChat.mockResolvedValueOnce({
-            result: JSON.stringify([
-                { name: 'NAME1', personId: 'p1' },
-                { name: 'NAME2', personId: 'p1' }, // duplicate
-            ]),
+            result: {
+                matches: [
+                    { name: 'NAME1', personId: 'p1' },
+                    { name: 'NAME2', personId: 'p1' }, // duplicate
+                ],
+            },
             usage: noUsage,
         });
 
@@ -283,19 +287,17 @@ describe('llmMatchMembers', () => {
         expect(result.stillUnmatched).toEqual(['NAME2']);
     });
 
-    it('handles trailing text after JSON array', async () => {
+    it('requests structured output instead of a prefill (rejected on Claude 4.6+)', async () => {
         mockAiChat.mockResolvedValueOnce({
-            result: '[{"name": "TEST", "personId": "p1"}]\n\nThe matching was done.',
+            result: { matches: [{ name: 'TEST', personId: 'p1' }] },
             usage: noUsage,
         });
 
-        const result = await llmMatchMembers(
-            ['TEST'],
-            [{ id: 'p1', name: 'Test Person' }],
-        );
+        await llmMatchMembers(['TEST'], [{ id: 'p1', name: 'Test Person' }]);
 
-        expect(result.matched).toEqual([{ name: 'TEST', personId: 'p1' }]);
-        expect(result.stillUnmatched).toEqual([]);
+        const callArgs = mockAiChat.mock.calls[0][0];
+        expect(callArgs.outputFormat).toBeDefined();
+        expect(callArgs.prefillSystemResponse).toBeUndefined();
     });
 });
 
@@ -319,9 +321,7 @@ describe('matchAllMembers', () => {
     it('falls back to LLM for token-sort misses', async () => {
         // "ΓΙΑΝΝΗΣ" is a nickname for "Ιωάννης" — token-sort can't match this
         mockAiChat.mockResolvedValueOnce({
-            result: JSON.stringify([
-                { name: 'ΠΑΠΑΔΟΠΟΥΛΟΣ ΓΙΑΝΝΗΣ', personId: 'p2' },
-            ]),
+            result: { matches: [{ name: 'ΠΑΠΑΔΟΠΟΥΛΟΣ ΓΙΑΝΝΗΣ', personId: 'p2' }] },
             usage: noUsage,
         });
 
@@ -342,9 +342,7 @@ describe('matchAllMembers', () => {
 
     it('reports truly unmatched names after both steps', async () => {
         mockAiChat.mockResolvedValueOnce({
-            result: JSON.stringify([
-                { name: 'ΑΓΝΩΣΤΟΣ ΑΝΘΡΩΠΟΣ', personId: null },
-            ]),
+            result: { matches: [{ name: 'ΑΓΝΩΣΤΟΣ ΑΝΘΡΩΠΟΣ', personId: null }] },
             usage: noUsage,
         });
 
@@ -489,7 +487,7 @@ describe('extractDecisionFromPdf', () => {
         fetchSpy.mockRestore();
     });
 
-    it('calls aiChat with correct model and prefill parameters', async () => {
+    it('calls aiChat with the current model and structured output (no prefill)', async () => {
         const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
             ok: true,
             arrayBuffer: () => Promise.resolve(new ArrayBuffer(50)),
@@ -512,10 +510,11 @@ describe('extractDecisionFromPdf', () => {
         await extractDecisionFromPdf('https://example.com/test-ai-params-url.pdf');
 
         expect(mockAiChat).toHaveBeenCalledWith(expect.objectContaining({
-            model: 'claude-sonnet-4-20250514',
-            prefillSystemResponse: '{',
-            prependToResponse: '{',
+            model: 'claude-sonnet-4-6',
+            outputFormat: expect.objectContaining({ type: 'json_schema' }),
         }));
+        // Assistant prefill is rejected by Claude 4.6+ models
+        expect(mockAiChat.mock.calls[0][0].prefillSystemResponse).toBeUndefined();
         expect(mockAiChat.mock.calls[0][0].documentBase64).toBeDefined();
         expect(mockAiChat.mock.calls[0][0].systemPrompt).toContain('ΠΑΡΟΝΤΕΣ');
 

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -482,6 +482,7 @@ Rules:
         }),
         outputFormat: { type: 'json_schema', schema: MEMBER_MATCH_SCHEMA },
         model: HAIKU_MODEL,
+        label: 'member-match',
     });
 
     const result = response.matches;
@@ -671,6 +672,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             outputFormat: { type: 'json_schema', schema: EXTRACTION_OUTPUT_SCHEMA },
             model: EXTRACTION_MODEL,
             maxTokens: EXTRACTION_MAX_TOKENS,
+            label: 'decision-extraction',
         });
 
         const result = normalizeExtraction(raw);
@@ -701,6 +703,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             outputFormat: { type: 'json_schema', schema: EXTRACTION_OUTPUT_SCHEMA },
             model: EXTRACTION_MODEL,
             maxTokens: EXTRACTION_MAX_TOKENS,
+            label: 'decision-extraction:partial',
         });
 
         totalUsage = addUsage(totalUsage, usage);
@@ -738,6 +741,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             outputFormat: { type: 'json_schema', schema: EXTRACTION_OUTPUT_SCHEMA },
             model: EXTRACTION_MODEL,
             maxTokens: EXTRACTION_MAX_TOKENS,
+            label: 'decision-extraction:tail',
         });
 
         totalUsage = addUsage(totalUsage, usage);

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -545,10 +545,11 @@ const EXTRACTION_MODEL = 'claude-sonnet-4-6';
 /**
  * Max output tokens for extraction — needs headroom for decisions with large
  * tables (budget amendments, etc.). Structured outputs cannot use aiChat's
- * max_tokens continuation, so the ceiling is generous; aiChat streams, so
- * values above 16K don't risk HTTP timeouts.
+ * max_tokens continuation (hitting the cap is a hard failure), so this is
+ * Sonnet 4.6's full output ceiling; aiChat streams, so large values don't
+ * risk HTTP timeouts.
  */
-const EXTRACTION_MAX_TOKENS = 32768;
+const EXTRACTION_MAX_TOKENS = 64000;
 
 // Structured-outputs schemas mirroring RawLlmExtraction — they replace the
 // '{' assistant prefill, which Claude 4.6+ models reject

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -419,6 +419,28 @@ export function matchPersonByName(
     return null;
 }
 
+// Structured-outputs schema for llmMatchMembers — replaces the '[' assistant
+// prefill, which Claude 4.6+ models reject
+const MEMBER_MATCH_SCHEMA = {
+    type: 'object' as const,
+    properties: {
+        matches: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    personId: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+                },
+                required: ['name', 'personId'],
+                additionalProperties: false,
+            },
+        },
+    },
+    required: ['matches'],
+    additionalProperties: false,
+};
+
 /**
  * Step 2: LLM fallback for names that couldn't be matched by token-sort.
  * Sends unmatched names + available people to haiku for semantic matching.
@@ -433,7 +455,7 @@ export async function llmMatchMembers(
 
     console.log(`  LLM matching ${unmatchedNames.length} unmatched names against ${availablePeople.length} people`);
 
-    const { result: rawResponse, usage } = await aiChat<string>({
+    const { result: response, usage } = await aiChat<{ matches: { name: string; personId: string | null }[] }>({
         systemPrompt: `You are a Greek name matcher for municipal council members.
 
 Match each name from "unmatchedNames" to its corresponding person from "availablePeople".
@@ -446,8 +468,8 @@ Names may differ in:
 
 **Key strategy**: When the surname matches exactly between an unmatched name and only ONE available person shares that surname, the first name is very likely a diminutive — match them even if the first name looks very different. If multiple available people share the same surname, only match when you can confidently identify the diminutive.
 
-Return ONLY a JSON array with one entry per unmatched name, no other text:
-[{"name": "<exact name from unmatchedNames>", "personId": "<id from availablePeople or null>"}]
+Return one entry in "matches" per unmatched name:
+{"matches": [{"name": "<exact name from unmatchedNames>", "personId": "<id from availablePeople or null>"}]}
 
 Rules:
 - "name" must be the EXACT string from unmatchedNames
@@ -458,19 +480,11 @@ Rules:
             unmatchedNames,
             availablePeople: availablePeople.map(p => ({ id: p.id, name: p.name })),
         }),
-        prefillSystemResponse: '[',
-        prependToResponse: '[',
-        parseJson: false,
+        outputFormat: { type: 'json_schema', schema: MEMBER_MATCH_SCHEMA },
         model: HAIKU_MODEL,
     });
 
-    // Strip any trailing text after the JSON array (LLM sometimes adds explanations)
-    const jsonEnd = rawResponse.lastIndexOf(']');
-    if (jsonEnd === -1) {
-        console.warn(`  LLM returned no valid JSON array, treating all as unmatched`);
-        return { matched: [], stillUnmatched: unmatchedNames, usage };
-    }
-    const result: { name: string; personId: string | null }[] = JSON.parse(rawResponse.slice(0, jsonEnd + 1));
+    const result = response.matches;
 
     const matched: { name: string; personId: string }[] = [];
     const stillUnmatched: string[] = [];
@@ -526,9 +540,93 @@ export async function matchAllMembers(
 
 // --- PDF extraction ---
 
-const EXTRACTION_MODEL = 'claude-sonnet-4-20250514';
-/** Max output tokens for extraction — needs headroom for decisions with large tables (budget amendments, etc.). */
-const EXTRACTION_MAX_TOKENS = 16384;
+const EXTRACTION_MODEL = 'claude-sonnet-4-6';
+
+/**
+ * Max output tokens for extraction — needs headroom for decisions with large
+ * tables (budget amendments, etc.). Structured outputs cannot use aiChat's
+ * max_tokens continuation, so the ceiling is generous; aiChat streams, so
+ * values above 16K don't risk HTTP timeouts.
+ */
+const EXTRACTION_MAX_TOKENS = 32768;
+
+// Structured-outputs schemas mirroring RawLlmExtraction — they replace the
+// '{' assistant prefill, which Claude 4.6+ models reject
+
+const AGENDA_ITEM_REF_SCHEMA = {
+    type: 'object' as const,
+    properties: {
+        agendaItemIndex: { type: 'integer' },
+        nonAgendaReason: { anyOf: [{ type: 'string', enum: ['outOfAgenda'] }, { type: 'null' }] },
+    },
+    required: ['agendaItemIndex', 'nonAgendaReason'],
+    additionalProperties: false,
+};
+
+const EXTRACTION_OUTPUT_SCHEMA = {
+    type: 'object' as const,
+    properties: {
+        attendanceFormat: { type: 'string', enum: ['composition_and_absent', 'explicit_present_absent'] },
+        compositionMembers: { anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }] },
+        presentMembers: { anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }] },
+        absentMembers: { type: 'array', items: { type: 'string' } },
+        mayorPresent: {
+            anyOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        present: { type: 'boolean' },
+                        rawText: { type: 'string' },
+                    },
+                    required: ['present', 'rawText'],
+                    additionalProperties: false,
+                },
+                { type: 'null' },
+            ],
+        },
+        decisionExcerpt: { type: 'string' },
+        decisionNumber: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        references: { type: 'string' },
+        voteResult: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        voteDetails: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    vote: { type: 'string', enum: ['FOR', 'AGAINST', 'ABSTAIN', 'PRESENT', 'DID_NOT_VOTE'] },
+                },
+                required: ['name', 'vote'],
+                additionalProperties: false,
+            },
+        },
+        attendanceChanges: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    type: { type: 'string', enum: ['arrival', 'departure'] },
+                    agendaItem: { anyOf: [AGENDA_ITEM_REF_SCHEMA, { type: 'null' }] },
+                    timing: { anyOf: [{ type: 'string', enum: ['during', 'after'] }, { type: 'null' }] },
+                    rawText: { type: 'string' },
+                },
+                required: ['name', 'type', 'agendaItem', 'timing', 'rawText'],
+                additionalProperties: false,
+            },
+        },
+        discussionOrder: { anyOf: [{ type: 'array', items: AGENDA_ITEM_REF_SCHEMA }, { type: 'null' }] },
+        subjectInfo: { anyOf: [AGENDA_ITEM_REF_SCHEMA, { type: 'null' }] },
+        incomplete: { type: 'boolean' },
+    },
+    required: [
+        'attendanceFormat', 'compositionMembers', 'presentMembers', 'absentMembers',
+        'mayorPresent', 'decisionExcerpt', 'decisionNumber', 'references',
+        'voteResult', 'voteDetails', 'attendanceChanges', 'discussionOrder',
+        'subjectInfo', 'incomplete',
+    ],
+    additionalProperties: false,
+};
 
 /** Page count threshold: PDFs with this many pages or fewer are sent whole. */
 const SMALL_PDF_THRESHOLD = 10;
@@ -569,8 +667,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             systemPrompt: EXTRACTION_SYSTEM_PROMPT,
             userPrompt,
             documentBase64: base64,
-            prefillSystemResponse: '{',
-            prependToResponse: '{',
+            outputFormat: { type: 'json_schema', schema: EXTRACTION_OUTPUT_SCHEMA },
             model: EXTRACTION_MODEL,
             maxTokens: EXTRACTION_MAX_TOKENS,
         });
@@ -600,8 +697,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             systemPrompt: EXTRACTION_SYSTEM_PROMPT,
             userPrompt: partialPrompt,
             documentBase64: partialBase64,
-            prefillSystemResponse: '{',
-            prependToResponse: '{',
+            outputFormat: { type: 'json_schema', schema: EXTRACTION_OUTPUT_SCHEMA },
             model: EXTRACTION_MODEL,
             maxTokens: EXTRACTION_MAX_TOKENS,
         });
@@ -638,8 +734,7 @@ export async function extractDecisionFromPdf(pdfUrl: string, mayorName?: string,
             systemPrompt: EXTRACTION_SYSTEM_PROMPT,
             userPrompt: tailPrompt,
             documentBase64: tailBase64,
-            prefillSystemResponse: '{',
-            prependToResponse: '{',
+            outputFormat: { type: 'json_schema', schema: EXTRACTION_OUTPUT_SCHEMA },
             model: EXTRACTION_MODEL,
             maxTokens: EXTRACTION_MAX_TOKENS,
         });

--- a/src/tasks/utils/decisionPdfExtraction.ts
+++ b/src/tasks/utils/decisionPdfExtraction.ts
@@ -273,25 +273,10 @@ Extract the following information from the PDF:
 13. **mayorPresent**: Whether the city mayor (Δήμαρχος/Δήμαρχο) was present at the session. This is usually stated in a narrative paragraph separate from the council member attendance list. Look for phrases like "Ο/Η Δήμαρχος ... προσκλήθηκε νομίμως και παρέστη" or "Ο/Η Δήμαρχος ... παρών/παρούσα" (present), or "Ο/Η Δήμαρχος ... δεν ήταν παρών/παρούσα" or "απουσίαζε" (absent). Return an object with "present" (boolean) and "rawText" (the original sentence from the PDF describing the mayor's presence/absence). Return null if mayor presence is not mentioned.
 14. **incomplete**: Set to true ONLY if the document appears physically truncated — i.e. you can see attendance lists and preamble but the decision section starting with "ΑΠΟΦΑΣΙΖΕΙ" is not present because the provided pages end before reaching it. Set to false if you can see the "ΑΠΟΦΑΣΙΖΕΙ" section, even if some fields within it (like the vote result phrase) are missing or unclear. Missing data in a complete document is a data quality issue, not truncation.
 
-Return valid JSON matching this schema:
-{
-  "attendanceFormat": "composition_and_absent" | "explicit_present_absent",
-  "compositionMembers": string[] | null,
-  "presentMembers": string[] | null,
-  "absentMembers": string[],
-  "mayorPresent": { "present": boolean, "rawText": string } | null,
-  "decisionExcerpt": string,
-  "decisionNumber": string | null,
-  "references": string,
-  "voteResult": string | null,
-  "voteDetails": { "name": string, "vote": "FOR" | "AGAINST" | "ABSTAIN" | "PRESENT" | "DID_NOT_VOTE" }[],
-  "attendanceChanges": { "name": string, "type": "arrival" | "departure", "agendaItem": { "agendaItemIndex": number, "nonAgendaReason": "outOfAgenda" | null } | null, "timing": "during" | "after" | null, "rawText": string }[],
-  "discussionOrder": { "agendaItemIndex": number, "nonAgendaReason": "outOfAgenda" | null }[] | null,
-  "subjectInfo": { "agendaItemIndex": number, "nonAgendaReason": "outOfAgenda" | null } | null,
-  "incomplete": boolean
-}
-
 If a field cannot be found, use empty array for lists, empty string for text, and null where indicated.`;
+// The output shape itself is not described here — it is enforced by
+// EXTRACTION_OUTPUT_SCHEMA via structured outputs, so the prompt only needs
+// the field-finding guidance above.
 
 // --- Greek name matching ---
 


### PR DESCRIPTION
## Why — time-sensitive

`claude-sonnet-4-20250514` (the pollDecisions PDF extraction model) **retires on June 15, 2026**. After that date every extraction call returns 404, breaking decision polling entirely.

The drop-in replacement is `claude-sonnet-4-6` — but the 4.6 model family **rejects assistant-message prefill** (400: "This model does not support assistant message prefill"), and these call sites used `prefillSystemResponse: '{'` / `'['` to force JSON output. So the model bump and the prefill removal must land together. (This is the same API change that bit fixTranscript's continuation logic in #43.)

## What

- `EXTRACTION_MODEL` → `claude-sonnet-4-6`
- All four prefill call sites migrate to **structured outputs** (`outputFormat: { type: 'json_schema', ... }`) — the pattern pollDecisions, summarize, and processAgenda already use:
  - the three PDF-extraction calls get `EXTRACTION_OUTPUT_SCHEMA`, mirroring `RawLlmExtraction` exactly (attendance formats, vote enums, agenda-item refs, nullables)
  - the Haiku member-name matcher gets `MEMBER_MATCH_SCHEMA`; its output moves from a bare JSON array to `{ matches: [...] }`, and the manual "strip trailing text after the array" cleanup is deleted — structured outputs can't produce preamble or commentary
- `EXTRACTION_MAX_TOKENS` 16384 → 32768: structured outputs can't use `aiChat`'s max_tokens continuation, and `aiChat` streams, so the larger ceiling costs nothing unless a giant budget-amendment table actually needs it
- Tests updated: mocks return the structured shape, the obsolete trailing-text test is replaced with a no-prefill assertion, and the model/params assertion tracks the new call shape

## Testing

`npm run typecheck && npm test` — 393 tests pass. The extraction prompt itself is unchanged (it already documented the JSON schema in prose; now the API enforces it).

## Notes

- Haiku 4.5 still accepts prefill, but the member matcher is migrated too — same file, same fragile pattern, and structured outputs is strictly more robust than the manual JSON cleanup it replaces.
- Worth a `pollDecisions` run against a real meeting after merge to sanity-check extraction quality on the new model.

https://claude.ai/code/session_01DAQpmUvpUMsvg2KFA8aZxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAQpmUvpUMsvg2KFA8aZxL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core pollDecisions LLM path (model swap + output contract); behavior should match enforced schemas, but real-PDF quality on 4.6 still warrants a post-merge sanity check.
> 
> **Overview**
> Migrates **pollDecisions** PDF decision extraction off retiring **`claude-sonnet-4-20250514`** to **`claude-sonnet-4-6`**, and drops **assistant prefill** (`'{'` / `'['`) in favor of **structured outputs** (`outputFormat: json_schema`), which Claude 4.6+ requires.
> 
> **`extractDecisionFromPdf`** (whole-doc, progressive front pages, and tail fallback) now uses **`EXTRACTION_OUTPUT_SCHEMA`** aligned with `RawLlmExtraction`. **`llmMatchMembers`** uses **`MEMBER_MATCH_SCHEMA`** with `{ matches: [...] }` instead of a raw JSON array; the manual “strip trailing text after `]`” parsing is removed. **`EXTRACTION_MAX_TOKENS`** rises **16 384 → 32 768** because structured output cannot rely on `aiChat` max-token continuation.
> 
> Tests mock the new response shapes and assert **`outputFormat`** is set and **`prefillSystemResponse`** is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6100085207d857a318ea57375b21c786706dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a time-sensitive migration off the retiring `claude-sonnet-4-20250514` model to `claude-sonnet-4-6`, and simultaneously drops assistant-message prefill (rejected by the 4.6 family) in favour of structured outputs across all four affected call sites.

- **Model + token ceiling:** `EXTRACTION_MODEL` → `claude-sonnet-4-6`; `EXTRACTION_MAX_TOKENS` raised to 64 000 (Sonnet 4.6's documented max output), safe to set high because `aiChat` streams.
- **Structured outputs:** The three `extractDecisionFromPdf` call sites receive `EXTRACTION_OUTPUT_SCHEMA` (a JSON Schema mirror of `RawLlmExtraction`); `llmMatchMembers` receives `MEMBER_MATCH_SCHEMA` wrapping the array in `{ matches: [...] }`, and the now-unnecessary manual `]`-index parse/trim is deleted.
- **Tests:** Mocks updated to the new response shapes; the obsolete trailing-text test is replaced with an assertion that `outputFormat` is set and `prefillSystemResponse` is absent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four prefill call sites are properly migrated, the JSON schemas faithfully mirror the TypeScript types, and 393 tests pass.

The change is a straightforward model swap and prefill-to-structured-outputs migration. EXTRACTION_OUTPUT_SCHEMA is verified to match every field of RawLlmExtraction, MEMBER_MATCH_SCHEMA correctly wraps the result array, and the max-tokens value of 64 000 aligns with claude-sonnet-4-6's published output ceiling. No logic changes were made to the extraction or matching pipeline itself.

No files require special attention; a post-merge pollDecisions run against a real meeting PDF is the only remaining validation gap.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/tasks/utils/decisionPdfExtraction.ts | Migrates EXTRACTION_MODEL to claude-sonnet-4-6, replaces all four assistant-prefill call sites with structured outputs (EXTRACTION_OUTPUT_SCHEMA / MEMBER_MATCH_SCHEMA), raises EXTRACTION_MAX_TOKENS to 64 000 (model's documented ceiling), and removes the manual JSON-array parse/trim logic in llmMatchMembers |
| src/tasks/utils/decisionPdfExtraction.test.ts | Test mocks updated to return structured-output shapes; model and outputFormat assertions track the new call shape; the now-obsolete trailing-text test is replaced with a no-prefill assertion |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(pollDecisions): drop prose JSON sc..."](https://github.com/schemalabz/opencouncil-tasks/commit/ae293f84cfc0c0b1635340bc29996782a1861bce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36930913)</sub>

<!-- /greptile_comment -->