### PR TITLE
feat(highlight): upscale highlight output to render.minResolution

### DIFF
--- a/src/tasks/generateHighlight.ts
+++ b/src/tasks/generateHighlight.ts
@@ -1,7 +1,7 @@
 import { createMuxAsset } from "../lib/mux.js";
 import { GenerateHighlightRequest, GenerateHighlightResult } from "../types.js";
 import { Task } from "./pipeline.js";
-import { splitAndUploadMedia, generateSocialFilter, generateCaptionFilters, generateSpeakerOverlayFilter, getVideoResolution, downloadFile } from "./utils/mediaOperations.js";
+import { splitAndUploadMedia, generateSocialFilter, generateCaptionFilters, generateSpeakerOverlayFilter, getVideoResolution, downloadFile, computeUpscalePlan } from "./utils/mediaOperations.js";
 
 /**
  * Merge consecutive video segments to simplify FFmpeg operations
@@ -151,6 +151,18 @@ export const generateHighlight: Task<
       partProgress(10);
     }
 
+    // Resolve the minimum-resolution upscale (default path only; social has its
+    // own sizing). The effective dimensions drive caption/overlay preset lookup
+    // so text is sized for the post-scale frame, not the source.
+    const upscale = computeUpscalePlan(
+      isSocial ? undefined : render.minResolution,
+      inputVideoWidth,
+      inputVideoHeight,
+    );
+    if (upscale.filter) {
+      console.log(`⬆️  Upscaling ${inputVideoWidth}x${inputVideoHeight} → ${upscale.width}x${upscale.height} to meet minResolution=${render.minResolution}; output quality is bounded by the source resolution.`);
+    }
+
     // Step 1: Social transformation (if needed)
     let baseFilter = '';
     if (isSocial) {
@@ -169,7 +181,7 @@ export const generateHighlight: Task<
     let speakerFilter = '';
     if (render.includeSpeakerOverlay) {
       console.log(`👤 Generating speaker overlays for ${adjustedUtterances.length} utterances`);
-      speakerFilter = await generateSpeakerOverlayFilter(adjustedUtterances, aspectRatio, inputVideoWidth || 1280, inputVideoHeight || 720);
+      speakerFilter = await generateSpeakerOverlayFilter(adjustedUtterances, aspectRatio, upscale.width, upscale.height);
       partProgress(isSocial ? 18 : 10);
     }
 
@@ -178,12 +190,14 @@ export const generateHighlight: Task<
     let captionFilter = '';
     if (render.includeCaptions) {
       console.log(`📝 Generating captions for ${adjustedUtterances.length} utterances in ${aspectRatio} format`);
-      captionFilter = await generateCaptionFilters(adjustedUtterances, aspectRatio, inputVideoWidth || 1280, inputVideoHeight || 720);
+      captionFilter = await generateCaptionFilters(adjustedUtterances, aspectRatio, upscale.width, upscale.height);
       partProgress(isSocial ? 20 : 15);
     }
 
-    // Combine all filters in the correct order
-    const filterParts = [baseFilter, speakerFilter, captionFilter].filter(f => f.length > 0);
+    // Combine all filters in the correct order. The upscale must run first, on
+    // the raw concatenated frames, so captions/overlays are drawn at the
+    // post-scale pixel positions their presets assume.
+    const filterParts = [upscale.filter, baseFilter, speakerFilter, captionFilter].filter(f => f.length > 0);
     if (filterParts.length > 0) {
       videoFilters = filterParts.join(',');
       console.log(`🎬 Combined filter chain: ${filterParts.length} filter(s)`);

--- a/src/tasks/utils/mediaOperations.test.ts
+++ b/src/tasks/utils/mediaOperations.test.ts
@@ -126,9 +126,19 @@ describe('getPresetConfig', () => {
     expect(config.caption['default'].startFont).toBe(32);
   });
 
-  it('falls back to first preset for unknown resolution', () => {
-    const { config } = getPresetConfig('9999x9999', 'default');
+  it('matches the nearest-height preset for an unknown resolution', () => {
+    // 9999 height is closest to the 2160 preset.
+    const { config, dimensions } = getPresetConfig('9999x9999', 'default');
     expect(config.caption['default']).toBeDefined();
+    expect(dimensions.height).toBe(2160);
+  });
+
+  it('uses the nearest-height preset for upscaled non-standard widths', () => {
+    // A 1282x720 source upscaled to 1080p becomes 1924x1080 — no exact key, but
+    // it must size captions/overlays for 1080p, not collapse to 720p.
+    const { config } = getPresetConfig('1924x1080', 'default');
+    expect(config.caption['default'].startFont).toBe(48);
+    expect(config.overlay['default'].baseFontSize).toBe(42);
   });
 
   it('swaps dimensions for social-9x16', () => {

--- a/src/tasks/utils/mediaOperations.test.ts
+++ b/src/tasks/utils/mediaOperations.test.ts
@@ -11,6 +11,7 @@ import {
   calculateSpeakerDisplaySegments,
   wrapSpeakerText,
   formatSpeakerInfo,
+  computeUpscalePlan,
 } from './mediaOperations.js';
 
 describe('normalizeUtteranceTimestamps', () => {
@@ -135,6 +136,59 @@ describe('getPresetConfig', () => {
     // 1280x720 → look up swapped 720x1280 → returns { width: 720, height: 1280 }
     expect(dimensions.width).toBe(720);
     expect(dimensions.height).toBe(1280);
+  });
+
+  it('returns the dedicated preset for upscaled 16:9 resolutions', () => {
+    const { config, dimensions } = getPresetConfig('1920x1080', 'default');
+    expect(dimensions).toEqual({ width: 1920, height: 1080 });
+    expect(config.caption['default'].startFont).toBe(48);
+    expect(config.overlay['default'].baseFontSize).toBe(42);
+  });
+
+  it('still falls back to the first (social-capable) preset when a swap-matched preset has no social config', () => {
+    // 1080x1920 → swapped 1920x1080 exists but is default-only. Using it would
+    // leave the social config undefined, so it must fall back to 1280x720.
+    const { config } = getPresetConfig('1080x1920', 'social-9x16');
+    expect(config.caption['social-9x16']).toBeDefined();
+    expect(config.overlay['social-9x16']).toBeDefined();
+  });
+});
+
+describe('computeUpscalePlan', () => {
+  it('returns no filter when no minResolution is requested', () => {
+    const plan = computeUpscalePlan(undefined, 1280, 720);
+    expect(plan.filter).toBe('');
+    expect(plan).toMatchObject({ width: 1280, height: 720 });
+  });
+
+  it('passes through (and defaults) when source dimensions are unknown', () => {
+    const plan = computeUpscalePlan('1080p', undefined, undefined);
+    expect(plan.filter).toBe('');
+    expect(plan).toMatchObject({ width: 1280, height: 720 });
+  });
+
+  it('does not downscale a source already at or above the target', () => {
+    expect(computeUpscalePlan('1080p', 1920, 1080).filter).toBe('');
+    const taller = computeUpscalePlan('720p', 1920, 1080);
+    expect(taller.filter).toBe('');
+    expect(taller).toMatchObject({ width: 1920, height: 1080 });
+  });
+
+  it('upscales a sub-target 16:9 source to the target height', () => {
+    const plan = computeUpscalePlan('1080p', 1280, 720);
+    expect(plan).toEqual({
+      filter: 'scale=1920:1080:flags=lanczos,setsar=1',
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it('rounds the derived width up to an even number for libx264', () => {
+    // 1282x720 → 1282*1080/720 = 1923 (odd) → bumped to 1924
+    const plan = computeUpscalePlan('1080p', 1282, 720);
+    expect(plan.width % 2).toBe(0);
+    expect(plan.width).toBe(1924);
+    expect(plan.filter).toBe('scale=1924:1080:flags=lanczos,setsar=1');
   });
 });
 

--- a/src/tasks/utils/mediaOperations.ts
+++ b/src/tasks/utils/mediaOperations.ts
@@ -304,7 +304,7 @@ export function getPresetConfig(resolution: string, aspectRatio: AspectRatio): {
         };
     }
     
-    // Default aspect ratio - direct lookup with fallback
+    // Default aspect ratio - exact lookup first
     if (RESOLUTION_PRESETS[resolution]) {
         const [width, height] = resolution.split('x').map(n => parseInt(n, 10));
         return {
@@ -312,8 +312,28 @@ export function getPresetConfig(resolution: string, aspectRatio: AspectRatio): {
             dimensions: { width, height }
         };
     }
-    
-    // Fallback: use first available preset
+
+    const [reqWidth, reqHeight] = resolution.split('x').map(n => parseInt(n, 10));
+
+    // No exact match: pick the preset whose height is closest to the requested
+    // one. Upscaled frames rarely land on an exact preset key (e.g. a 1282x720
+    // source becomes 1924x1080), so matching on height keeps caption/overlay
+    // sizing tied to the real output resolution instead of always collapsing to
+    // the smallest preset.
+    if (Number.isFinite(reqHeight)) {
+        const nearest = Object.keys(RESOLUTION_PRESETS)
+            .map(key => {
+                const [width, height] = key.split('x').map(n => parseInt(n, 10));
+                return { key, width, height };
+            })
+            .sort((a, b) => Math.abs(a.height - reqHeight) - Math.abs(b.height - reqHeight))[0];
+        return {
+            config: RESOLUTION_PRESETS[nearest.key],
+            dimensions: { width: nearest.width, height: nearest.height }
+        };
+    }
+
+    // Unparseable resolution: fall back to the first preset.
     const firstPresetKey = Object.keys(RESOLUTION_PRESETS)[0];
     const [fallbackWidth, fallbackHeight] = firstPresetKey.split('x').map(n => parseInt(n, 10));
     return {

--- a/src/tasks/utils/mediaOperations.ts
+++ b/src/tasks/utils/mediaOperations.ts
@@ -4,7 +4,7 @@ import { ffmpegPath } from '../../lib/ffmpegPath.js';
 import fs from "fs";
 import { promisify } from "util";
 import { uploadToSpaces } from "../uploadToSpaces.js";
-import { SplitMediaFileRequest, MediaType, GenerateHighlightRequest, AspectRatio } from "../../types.js";
+import { SplitMediaFileRequest, MediaType, GenerateHighlightRequest, AspectRatio, MinResolution } from "../../types.js";
 
 const execAsync = promisify(cp.exec);
 
@@ -134,7 +134,140 @@ const RESOLUTION_PRESETS: Record<string, ResolutionPreset> = {
             // NOTE: social-9x16 Defaults to 1080p's social-9x16 preset
         },
     },
+    // The presets below back the `render.minResolution` upscale path. Values are
+    // scaled proportionally from the 1280x720 'default' preset (x1.5 / x2 / x3) so
+    // captions and overlays stay legible on the larger frame. They carry no
+    // social-9x16 sub-config: minResolution only applies to the 16:9 ('default')
+    // path, and the social swap-lookup falls back when no social config exists.
+    // Keyed for 16:9 output; non-16:9 upscales fall back to the 1280x720 preset.
+    // 1920x1080 (Full HD)
+    "1920x1080": {
+        caption: {
+            'default': {
+                startFont: 48,
+                maxFont: 54,
+                bottomPadding: 210,
+                sidePadding: 45,
+                maxLines: 3
+            },
+        },
+        overlay: {
+            'default': {
+                topPadding: 30,
+                leftPadding: 30,
+                baseFontSize: 42,
+                maxWidth: 675,
+                paddingH: 18,
+                paddingV: 12,
+                lineSpacing: 6,
+                accentWidth: 5,
+            },
+        },
+    },
+    // 2560x1440 (QHD)
+    "2560x1440": {
+        caption: {
+            'default': {
+                startFont: 64,
+                maxFont: 72,
+                bottomPadding: 280,
+                sidePadding: 60,
+                maxLines: 3
+            },
+        },
+        overlay: {
+            'default': {
+                topPadding: 40,
+                leftPadding: 40,
+                baseFontSize: 56,
+                maxWidth: 900,
+                paddingH: 24,
+                paddingV: 16,
+                lineSpacing: 8,
+                accentWidth: 6,
+            },
+        },
+    },
+    // 3840x2160 (4K UHD)
+    "3840x2160": {
+        caption: {
+            'default': {
+                startFont: 96,
+                maxFont: 108,
+                bottomPadding: 420,
+                sidePadding: 90,
+                maxLines: 3
+            },
+        },
+        overlay: {
+            'default': {
+                topPadding: 60,
+                leftPadding: 60,
+                baseFontSize: 84,
+                maxWidth: 1350,
+                paddingH: 36,
+                paddingV: 24,
+                lineSpacing: 12,
+                accentWidth: 9,
+            },
+        },
+    },
 };
+
+// Minimum output height (px) for each supported minResolution tier.
+const MIN_RESOLUTION_HEIGHT: Record<MinResolution, number> = {
+    '720p': 720,
+    '1080p': 1080,
+    '1440p': 1440,
+    '2160p': 2160,
+};
+
+/**
+ * Work out how to satisfy a `minResolution` floor for the default (16:9) path.
+ *
+ * Returns the ffmpeg scale filter (empty when no scaling is needed) plus the
+ * effective output dimensions, which callers feed into `getPresetConfig` so
+ * caption/overlay sizing matches the post-scale frame rather than the source.
+ *
+ * Behaviour:
+ * - No target, or unknown source dimensions: no scaling, dimensions pass through
+ *   (falling back to 1280x720 when unknown, matching the rest of the pipeline).
+ * - Source already at or above the target height: no scaling (this is a floor,
+ *   never a downscale).
+ * - Source below the target: scale to the target height, width derived from the
+ *   source aspect ratio and rounded to an even number (libx264 requires even
+ *   dimensions). The width is written explicitly into the filter so the filter
+ *   and the dimensions used for preset lookup cannot diverge. `setsar=1` keeps
+ *   anamorphic (non-square-pixel) sources displaying correctly.
+ */
+export function computeUpscalePlan(
+    minResolution: MinResolution | undefined,
+    inputWidth: number | undefined,
+    inputHeight: number | undefined,
+): { filter: string; width: number; height: number } {
+    const passthroughWidth = inputWidth ?? 1280;
+    const passthroughHeight = inputHeight ?? 720;
+
+    if (!minResolution || !inputWidth || !inputHeight) {
+        return { filter: '', width: passthroughWidth, height: passthroughHeight };
+    }
+
+    const targetHeight = MIN_RESOLUTION_HEIGHT[minResolution];
+    if (inputHeight >= targetHeight) {
+        return { filter: '', width: inputWidth, height: inputHeight };
+    }
+
+    let scaledWidth = Math.round((inputWidth * targetHeight) / inputHeight);
+    if (scaledWidth % 2 !== 0) {
+        scaledWidth += 1;
+    }
+
+    return {
+        filter: `scale=${scaledWidth}:${targetHeight}:flags=lanczos,setsar=1`,
+        width: scaledWidth,
+        height: targetHeight,
+    };
+}
 
 /**
  * Get preset configuration and dimensions for a given resolution and aspect ratio
@@ -149,16 +282,20 @@ export function getPresetConfig(resolution: string, aspectRatio: AspectRatio): {
     if (aspectRatio === 'social-9x16') {
         const [width, height] = resolution.split('x').map(n => parseInt(n, 10));
         const swappedResolution = `${height}x${width}`;
-        
-        // Try exact match first
-        if (RESOLUTION_PRESETS[swappedResolution]) {
+
+        // Use the swap-matched preset only if it actually carries a social-9x16
+        // config; otherwise fall back. Some presets are default-only (e.g. the
+        // minResolution upscale presets and 640x360), and returning one here
+        // would leave callers with an undefined social config and throw.
+        const swapped = RESOLUTION_PRESETS[swappedResolution];
+        if (swapped && swapped.caption['social-9x16'] && swapped.overlay['social-9x16']) {
             return {
-                config: RESOLUTION_PRESETS[swappedResolution],
+                config: swapped,
                 dimensions: { width: height, height: width } // Swapped for social
             };
         }
-        
-        // Fallback: use first available preset for social
+
+        // Fallback: first preset that has a social config (1280x720 ships one).
         const firstPresetKey = Object.keys(RESOLUTION_PRESETS)[0];
         const [fallbackWidth, fallbackHeight] = firstPresetKey.split('x').map(n => parseInt(n, 10));
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,6 +381,9 @@ export interface GenerateHighlightRequest extends TaskRequest {
         includeCaptions?: boolean;
         includeSpeakerOverlay?: boolean;
         aspectRatio?: AspectRatio;
+        // Minimum output height. Sources below it are upscaled to meet it; sources
+        // at or above it are left untouched. Applied to the 'default' path only.
+        minResolution?: MinResolution;
 
         // Social media formatting options (only used when aspectRatio is 'social-9x16')
         socialOptions?: {
@@ -392,6 +395,7 @@ export interface GenerateHighlightRequest extends TaskRequest {
 }
 // Shared rendering types
 export type AspectRatio = 'default' | 'social-9x16';
+export type MinResolution = '720p' | '1080p' | '1440p' | '2160p';
 
 export interface GenerateHighlightResult {
     parts: Array<{


### PR DESCRIPTION
Closes #64.

The highlight renderer never scaled the default (16:9) output — it kept whatever resolution the source had, so a meeting recorded below 1080p produced a sub-1080p highlight. The frontend now sends `render.minResolution`, defaulting to 1080p (schemalabz/opencouncil#501); this is the backend half that acts on it.

### What it does

On the default path, if the source is shorter than the requested minimum, the output is upscaled to that height. It's a floor: a source already at or above the target is left alone, never downscaled. Social (9x16) keeps its own sizing and ignores `minResolution`.

The scale filter runs first in the chain, before captions and speaker overlays are drawn, so the text lands at the right pixel positions for the final frame. The width is written explicitly into the filter (derived from the source aspect ratio, rounded to an even number for libx264) so the filter and the dimensions used for preset lookup can't drift apart. `setsar=1` keeps anamorphic sources displaying correctly.

### The preset part

Captions and overlays read fixed pixel sizes from `RESOLUTION_PRESETS`, which only had `1280x720` and `640x360`. Upscale to 1080p and the old code fell back to the 720p preset, so the text came out too small for the bigger frame. I added `1920x1080`, `2560x1440`, and `3840x2160` presets, scaled proportionally from the 720p base, and the generators now receive the post-scale dimensions instead of the source ones.

### Also in here

`getPresetConfig`'s social-9x16 branch could return a preset with no social config (the new default-only presets, and `640x360` already), which makes callers throw on an undefined config. It now only uses a swap-matched preset that actually carries a social config, and falls back to `1280x720` otherwise. That also fixes a pre-existing latent throw for `640x360`-swapped social sources.

### Resolution matching

Upscaled output rarely lands on an exact preset key — a `1282x720` source becomes `1924x1080`, and non-16:9 sources never will. So `getPresetConfig` now matches on nearest height when there's no exact key, keeping caption and overlay sizing tied to the real output resolution instead of collapsing to the smallest preset.

### Tested

`computeUpscalePlan`, the new presets, the nearest-height match, and the social fallback all have unit tests: floor behavior, unknown dimensions, even-width rounding, non-standard upscale widths. Full suite is 468 passing, built and tested on a clean checkout.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `minResolution` floor to the highlight renderer so that sources recorded below a target resolution (defaulting to 1080p from the frontend) are upscaled before captions and overlays are drawn, ensuring text is sized for the post-scale frame. The social (9:16) path is intentionally excluded and preserves its existing sizing.

- `computeUpscalePlan` derives the scale filter and effective output dimensions (floor semantics, even-width rounding for libx264, `setsar=1` for anamorphic safety); dimensions feed `getPresetConfig` so presets match the post-scale frame.
- New `1920x1080`, `2560x1440`, and `3840x2160` presets are added, proportionally scaled from 720p; a nearest-height fallback replaces the blind first-preset fallback in `getPresetConfig` for non-exact-key lookups.
- The social preset lookup is hardened to only use a swap-matched preset when it actually carries a social config, preventing a latent undefined-config throw for `640x360` and the new default-only presets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the upscale is a floor-only operation with clean passthrough for unknown dimensions and the social path is fully isolated from it.

The logic is well-scoped: `computeUpscalePlan` handles all edge cases (undefined dimensions, no-op for already-qualifying sources, even-width rounding), and the nearest-height fallback in `getPresetConfig` is a strict improvement over collapsing to the smallest preset. Test coverage covers the main cases. The one new finding is an unused destructured variable.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/tasks/generateHighlight.ts | Wires `computeUpscalePlan` into the highlight pipeline; upscale filter is correctly prepended before captions/overlays, and social path is correctly excluded from upscaling. |
| src/tasks/utils/mediaOperations.ts | Adds `computeUpscalePlan`, new 1080p/1440p/4K presets, nearest-height fallback in `getPresetConfig`, and a guarded social preset lookup; one unused `reqWidth` variable in the nearest-height path. |
| src/tasks/utils/mediaOperations.test.ts | Good unit-test coverage for `computeUpscalePlan` (floor, passthrough, even-width rounding) and updated `getPresetConfig` tests for the nearest-height and social fallback paths. |
| src/types.ts | Adds `MinResolution` type and optional `minResolution` field to `GenerateHighlightRequest`; straightforward, no issues. |

<sub>Reviews (2): Last reviewed commit: ["fix(highlight): size captions/overlays b..."](https://github.com/schemalabz/opencouncil-tasks/commit/068ff3c48ebbe48a73d1d20e48c7ab1e98bd9a55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39504875)</sub>

<!-- /greptile_comment -->