### PR TITLE
feat: render highlights and source video at 1080p by default

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -135,7 +135,7 @@ app.post('/transcribe', (
 }, taskManager.registerTask(pipeline, {
     summary: 'Transcribe audio/video content',
     description: 'Convert audio or video content to text using speech recognition',
-    version: 1,
+    version: 2,
 }));
 
 app.post('/summarize', taskManager.registerTask(summarize, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -168,7 +168,8 @@ app.post('/generateVoiceprint', taskManager.registerTask(generateVoiceprint, {
 
 app.post('/generateHighlight', taskManager.registerTask(generateHighlight, {
   summary: 'Generate video highlight',
-  description: 'Create video highlights from source media with visual enhancements'
+  description: 'Create video highlights from source media with visual enhancements',
+  version: 1,
 }));
 
 app.post('/pollDecisions', taskManager.registerTask(pollDecisions, {

--- a/src/tasks/downloadYTV.ts
+++ b/src/tasks/downloadYTV.ts
@@ -8,7 +8,7 @@ import { YtDlp, type FormatOptions, type VideoProgress } from "ytdlp-nodejs";
 
 dotenv.config();
 
-const DEFAULT_VIDEO_QUALITY = "720";
+const DEFAULT_VIDEO_QUALITY = "1080";
 const YTDLP_BIN_PATH = process.env.YTDLP_BIN_PATH;
 
 export const downloadYTV: Task<string, { audioOnly: string, combined: string, sourceType: string }> = async (youtubeUrl, onProgress) => {

--- a/src/tasks/utils/mediaOperations.test.ts
+++ b/src/tasks/utils/mediaOperations.test.ts
@@ -132,9 +132,31 @@ describe('getPresetConfig', () => {
 
   it('swaps dimensions for social-9x16', () => {
     const { dimensions } = getPresetConfig('1280x720', 'social-9x16');
-    // 1280x720 → look up swapped 720x1280 → returns { width: 720, height: 1280 }
+    // 720p landscape source → 720x1280 portrait canvas
     expect(dimensions.width).toBe(720);
     expect(dimensions.height).toBe(1280);
+  });
+
+  it('produces a 1080x1920 portrait canvas from a 1080p source', () => {
+    const { dimensions, config } = getPresetConfig('1920x1080', 'social-9x16');
+    expect(dimensions.width).toBe(1080);
+    expect(dimensions.height).toBe(1920);
+    // config comes from the matched 1080p preset, so it carries a social config
+    expect(config.caption['social-9x16']).toBeDefined();
+  });
+
+  it('caps social output at 1080p for larger-than-1080p sources', () => {
+    const { dimensions } = getPresetConfig('3840x2160', 'social-9x16');
+    expect(dimensions.width).toBe(1080);
+    expect(dimensions.height).toBe(1920);
+  });
+
+  it('borrows a social-capable preset for default-only resolutions (no throw)', () => {
+    // 640x360 has no social config; nearest social-capable preset is 1280x720
+    const { dimensions, config } = getPresetConfig('640x360', 'social-9x16');
+    expect(dimensions.width).toBe(720);
+    expect(dimensions.height).toBe(1280);
+    expect(config.caption['social-9x16']).toBeDefined();
   });
 });
 

--- a/src/tasks/utils/mediaOperations.ts
+++ b/src/tasks/utils/mediaOperations.ts
@@ -180,6 +180,38 @@ const RESOLUTION_PRESETS: Record<string, ResolutionPreset> = {
 };
 
 /**
+ * Pick the landscape preset best suited to render a 9:16 social clip from a
+ * landscape source of the given resolution.
+ *
+ * Presets are keyed by landscape resolution but not all carry a social-9x16
+ * config, so we only consider those that do. An exact match wins; otherwise we
+ * take the preset whose height is nearest the source height, preferring the
+ * larger preset on a tie. This caps social output at the largest social-capable
+ * preset (1920x1080 → 1080x1920) and guarantees a defined social config, so a
+ * source like 640x360 (default-only) safely borrows 1280x720 instead of throwing.
+ */
+function findSocialPresetKey(resolution: string): string {
+    const socialKeys = Object.keys(RESOLUTION_PRESETS).filter(
+        k => RESOLUTION_PRESETS[k].caption['social-9x16'] && RESOLUTION_PRESETS[k].overlay['social-9x16']
+    );
+
+    if (socialKeys.includes(resolution)) {
+        return resolution;
+    }
+
+    const srcHeight = parseInt(resolution.split('x')[1], 10);
+    return socialKeys.reduce((best, key) => {
+        const keyHeight = parseInt(key.split('x')[1], 10);
+        const bestHeight = parseInt(best.split('x')[1], 10);
+        const dKey = Math.abs(keyHeight - srcHeight);
+        const dBest = Math.abs(bestHeight - srcHeight);
+        if (dKey < dBest) return key;
+        if (dKey === dBest && keyHeight > bestHeight) return key; // tie → larger preset
+        return best;
+    });
+}
+
+/**
  * Get preset configuration and dimensions for a given resolution and aspect ratio
  * Handles 9:16 aspect ratio by finding corresponding 16:9 preset
  * Uses sequential fallback (first available preset) if exact match not found
@@ -188,25 +220,14 @@ export function getPresetConfig(resolution: string, aspectRatio: AspectRatio): {
     config: ResolutionPreset;
     dimensions: { width: number; height: number };
 } {
-    // Handle 9:16 aspect ratio by finding corresponding 16:9 preset
+    // Handle 9:16 aspect ratio by finding the matching landscape preset (presets
+    // are landscape-keyed) and swapping its dimensions to portrait for the output.
     if (aspectRatio === 'social-9x16') {
-        const [width, height] = resolution.split('x').map(n => parseInt(n, 10));
-        const swappedResolution = `${height}x${width}`;
-        
-        // Try exact match first
-        if (RESOLUTION_PRESETS[swappedResolution]) {
-            return {
-                config: RESOLUTION_PRESETS[swappedResolution],
-                dimensions: { width: height, height: width } // Swapped for social
-            };
-        }
-        
-        // Fallback: use first available preset for social
-        const firstPresetKey = Object.keys(RESOLUTION_PRESETS)[0];
-        const [fallbackWidth, fallbackHeight] = firstPresetKey.split('x').map(n => parseInt(n, 10));
+        const presetKey = findSocialPresetKey(resolution);
+        const [presetWidth, presetHeight] = presetKey.split('x').map(n => parseInt(n, 10));
         return {
-            config: RESOLUTION_PRESETS[firstPresetKey],
-            dimensions: { width: fallbackHeight, height: fallbackWidth } // Swapped for social
+            config: RESOLUTION_PRESETS[presetKey],
+            dimensions: { width: presetHeight, height: presetWidth } // Swapped landscape→portrait
         };
     }
     

--- a/src/tasks/utils/mediaOperations.ts
+++ b/src/tasks/utils/mediaOperations.ts
@@ -68,6 +68,8 @@ type ResolutionPreset = {
 
 const RESOLUTION_PRESETS: Record<string, ResolutionPreset> = {
     // 1280x720 (HD)
+    // NOTE: keep this first — getPresetConfig falls back to the first key for
+    // unknown input resolutions, and 720p font/padding values are the safest default.
     "1280x720": {
         caption: {
             'default': {
@@ -108,6 +110,47 @@ const RESOLUTION_PRESETS: Record<string, ResolutionPreset> = {
             },
         },
     },
+    // 1920x1080 (Full HD) — values scaled 1.5x from the 1280x720 preset
+    "1920x1080": {
+        caption: {
+            'default': {
+                startFont: 48,
+                maxFont: 54,
+                bottomPadding: 210,
+                sidePadding: 45,
+                maxLines: 3
+            },
+            'social-9x16': {
+                startFont: 48,
+                maxFont: 60,
+                bottomPadding: 600,
+                sidePadding: 45,
+                maxLines: 6
+            },
+        },
+        overlay: {
+            'default': {
+                topPadding: 30,
+                leftPadding: 30,
+                baseFontSize: 42,
+                maxWidth: 675,
+                paddingH: 18,
+                paddingV: 12,
+                lineSpacing: 6,
+                accentWidth: 4,
+            },
+            'social-9x16': {
+                topPadding: 525,
+                leftPadding: 30,
+                baseFontSize: 30,
+                maxWidth: 675,
+                paddingH: 18,
+                paddingV: 12,
+                lineSpacing: 6,
+                accentWidth: 4,
+            },
+        },
+    },
     // 640x360 (nHD)
     "640x360": {
         caption: {
@@ -118,7 +161,7 @@ const RESOLUTION_PRESETS: Record<string, ResolutionPreset> = {
                 sidePadding: 15,
                 maxLines: 3
             }
-            // NOTE: social-9x16 Defaults to 1080p's social-9x16 preset
+            // NOTE: social-9x16 falls back to the first preset's (1280x720) social-9x16 config
         },
         overlay: {
             'default': {
@@ -131,7 +174,7 @@ const RESOLUTION_PRESETS: Record<string, ResolutionPreset> = {
                 lineSpacing: 3,
                 accentWidth: 2,
             }
-            // NOTE: social-9x16 Defaults to 1080p's social-9x16 preset
+            // NOTE: social-9x16 falls back to the first preset's (1280x720) social-9x16 config
         },
     },
 };


### PR DESCRIPTION
## What

Two related changes that lift the pipeline to 1080p by default, using **real** resolution rather than upscaling:

1. **Source download** — bump `DEFAULT_VIDEO_QUALITY` 720 → 1080 in [`downloadYTV.ts`](src/tasks/downloadYTV.ts) so yt-dlp fetches genuine 1080p when the source provides it. This lifts the hosted Mux video *and* highlights.
2. **Vertical highlights** — fix the social-9x16 dimension logic so vertical clips render at **1080×1920** by default instead of being pinned to 720×1280.

## Why this instead of render-time upscaling ([#65](https://github.com/schemalabz/opencouncil-tasks/pull/65))

[#65](https://github.com/schemalabz/opencouncil-tasks/pull/65) reaches the same goal (#64) by upscaling highlight output to a `minResolution` floor — interpolated/soft 1080p, and only on the default 16:9 path (it explicitly excludes social). This PR instead fetches real 1080p at the source and fixes the genuine resolution bug in the vertical path. Trade-off: a meeting only available below 1080p stays native (we don't fake it via upscaling); council streams that are genuinely 1080p are the case this helps.

## Resolution outcomes

| Source | Default (16:9) highlight | Vertical (9:16) highlight |
|---|---|---|
| ≤720p | native (e.g. 1280×720) | 720×1280 |
| **1080p** | **1920×1080** ✅ | **1080×1920** ✅ |
| >1080p | up to native | 1080×1920 (capped) |

## The default (16:9) path

Already size-agnostic (output res = input res), so a 1080p source yields a 1080p highlight for free. Captions/overlays read fixed pixel sizes from `RESOLUTION_PRESETS`, which only had `1280x720` and `640x360` — a 1080p frame fell back to 720p sizing. Added a `1920x1080` preset (values scaled 1.5× from 720p) so text is sized for the larger frame.

## The vertical (9:16) path — the real bug

`getPresetConfig`'s social branch took the landscape source resolution, **swapped it to portrait**, and looked that up in the **landscape-keyed** preset table. That lookup never matched, so social output always fell back to the first preset (`1280x720`) → every vertical highlight was pinned to **720×1280**, downscaling even a 1080p source.

Fixed by matching the source (landscape) resolution against social-capable presets directly (exact, else nearest height, ties prefer the larger preset), then swapping to portrait for the output:

- 1080p source → `1080×1920`
- larger sources → capped at `1080×1920`
- 720p → `720×1280` (native)

This also guarantees a defined social config, fixing a **latent throw** for default-only resolutions like `640x360` (they now borrow the `1280x720` social config). Unit tests added for each case.

## Versioning

- **transcribe** task `version` 1 → 2 (hosted video resolution changes)
- **generateHighlight** task gains `version: 1` (output dimensions change)

## Known limitation / out of scope

The default (16:9) path still falls back to 720p caption/overlay sizing for sources **above** 1080p (no >1080p presets), since the download cap means YouTube sources won't exceed 1080p. Nearest-height matching for the default path (as in #65) could be a follow-up.

## Tested

`npm run typecheck && npm test` — 459 passing. Social dimensions verified empirically across 720p/1080p/4K/360p sources.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the default video pipeline output to real 1080p where source media supports it. The main changes are:

- Default YouTube download quality moves from 720p to 1080p.
- Social 9:16 highlight sizing now selects landscape presets before producing portrait dimensions.
- A 1920x1080 preset is added for captions and overlays.
- Task version metadata is updated for transcribe and highlight generation.
- Tests cover 720p, 1080p, larger-source capping, and fallback social dimensions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/tasks/utils/mediaOperations.ts | Adds 1080p caption and overlay settings and fixes social 9:16 preset selection from landscape source dimensions. |
| src/tasks/downloadYTV.ts | Raises the default YouTube download quality from 720p to 1080p. |
| src/server.ts | Updates task version metadata for transcribe and highlight generation. |
| src/tasks/utils/mediaOperations.test.ts | Adds coverage for social highlight dimensions across common source resolutions. |

<sub>Reviews (4): Last reviewed commit: ["feat(highlight): render vertical highlig..."](https://github.com/schemalabz/opencouncil-tasks/commit/840a77095472ec6888976c691b5ff226eb7b7a85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40816493)</sub>

<!-- /greptile_comment -->