### PR TITLE
feat(scripts): add poll-livestreams cron wrapper

### DIFF
--- a/scripts/poll-livestreams-cron.sh
+++ b/scripts/poll-livestreams-cron.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Cron script for automated livestream matching and transcription.
+#
+# Calls the opencouncil poll-livestreams endpoint on a schedule. Each run the
+# endpoint finds council meetings scheduled within ±12h of now, matches each to a
+# recent video on its administrative body's YouTube channel (via the YouTube Data
+# API + Claude), and triggers transcription for confident single-meeting matches.
+# Videos that appear to cover multiple meetings are left for manual handling and
+# raise a one-time Discord alert.
+#
+# Prerequisites:
+#   1. The opencouncil deployment must have set in its environment:
+#        - CRON_SECRET       (same secret as below)
+#        - YOUTUBE_API_KEY   (else the endpoint no-ops)
+#        - CACHE_URL         (optional; without it the multi-meeting alert may repeat)
+#      Each administrative body to poll must have youtubeChannelUrl set.
+#   2. Add CRON_TARGET_URL and CRON_SECRET to this server's .env:
+#        CRON_TARGET_URL=https://opencouncil.gr
+#        CRON_SECRET=<same secret as the opencouncil deployment>
+#
+# Setup:
+#   1. Test manually:  ./scripts/poll-livestreams-cron.sh
+#      (append ?dryRun=1 to ENDPOINT below, or curl it by hand, to log decisions
+#       without triggering transcription or posting alerts)
+#   2. Install cron (runs every 15 minutes):
+#        crontab -e
+#        */15 * * * * /path/to/opencouncil-tasks/scripts/poll-livestreams-cron.sh >> /path/to/opencouncil-tasks/logs/poll-livestreams-cron.log 2>&1
+#   3. Create logs dir:  mkdir -p logs
+#
+# Monitoring:
+#   - Logs: tail -f logs/poll-livestreams-cron.log
+#   - Auto-match and multi-meeting notifications are posted to the admin Discord
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Load .env from the project root
+ENV_FILE="$SCRIPT_DIR/../.env"
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+if [[ -z "${CRON_TARGET_URL:-}" ]]; then
+    echo "Error: CRON_TARGET_URL is not set"
+    exit 1
+fi
+
+if [[ -z "${CRON_SECRET:-}" ]]; then
+    echo "Error: CRON_SECRET is not set"
+    exit 1
+fi
+
+ENDPOINT="${CRON_TARGET_URL}/api/cron/poll-livestreams"
+
+echo "[$(date -Iseconds)] Polling ${ENDPOINT}"
+RESPONSE=$(curl -sf -H "Authorization: Bearer ${CRON_SECRET}" "${ENDPOINT}" 2>&1) || {
+    echo "[$(date -Iseconds)] ERROR: curl failed (exit $?)"
+    echo "$RESPONSE"
+    exit 1
+}
+
+echo "[$(date -Iseconds)] OK: ${RESPONSE}"


### PR DESCRIPTION
## Summary

Adds `scripts/poll-livestreams-cron.sh`, a sibling to the existing `poll-decisions-cron.sh`, so the tasks server can drive **automatic livestream matching + transcription** on a schedule.

The web app ([opencouncil#513](https://github.com/schemalabz/opencouncil/pull/513)) added the `GET /api/cron/poll-livestreams` endpoint but nothing was calling it — production runs on DO App Platform (no crontab), so the scheduler lives here on the tasks droplet next to `poll-decisions`. This wrapper closes that gap.

## What it does

Identical mechanics to `poll-decisions-cron.sh`:
- Sources `CRON_TARGET_URL` and `CRON_SECRET` from the project-root `.env`
- `curl`s `${CRON_TARGET_URL}/api/cron/poll-livestreams` with the bearer secret
- Logs a timestamped OK/ERROR line and exits non-zero on curl failure

Each endpoint run finds meetings scheduled within ±12h, matches each to a recent video on its administrative body's YouTube channel (YouTube Data API + Claude), and triggers transcription for confident single-meeting matches. Multi-meeting videos are left for manual handling with a one-time Discord alert.

## Deploy (on the tasks droplet)

```bash
git pull
mkdir -p logs
./scripts/poll-livestreams-cron.sh            # manual smoke test
crontab -e
# every 15 minutes:
*/15 * * * * /root/opencouncil-tasks/scripts/poll-livestreams-cron.sh >> /root/opencouncil-tasks/logs/poll-livestreams-cron.log 2>&1
```

## Prerequisites (opencouncil app env)

- `CRON_SECRET` — same value as this server's `.env`
- `YOUTUBE_API_KEY` — else the endpoint no-ops
- `CACHE_URL` (optional) — without it the multi-meeting alert may repeat
- Each polled administrative body must have `youtubeChannelUrl` set

## Testing

- `bash -n` syntax check passes
- Body diff vs `poll-decisions-cron.sh` is only the endpoint path

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `scripts/poll-livestreams-cron.sh`, a cron wrapper that polls the `GET /api/cron/poll-livestreams` endpoint, complementing the existing `poll-decisions-cron.sh`. The implementation faithfully mirrors the sibling script's structure — `.env` sourcing, env-var validation, bearer-auth `curl`, and timestamped logging.

- Functional logic is identical to `poll-decisions-cron.sh`; no new runtime behavior is introduced in this wrapper.
- There is a minor inconsistency between the recommended cron schedule in the script header (`*/15`) and the `*/30` shown in the PR's deploy instructions — worth aligning before operators install it.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the script is a straightforward copy of an existing, proven pattern with only the endpoint path changed.

The change is a single new shell script that mirrors poll-decisions-cron.sh exactly. The env-var validation, bearer-auth curl call, and error handling are all copy-verified against the working sibling. There are no new runtime paths or security boundaries introduced.

No files require special attention beyond aligning the cron schedule (*/15 vs */30) in the header comment before operators install it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/poll-livestreams-cron.sh | New cron wrapper for the poll-livestreams endpoint, mirroring poll-decisions-cron.sh; minor schedule mismatch between the script header and the PR deploy instructions (*/15 vs */30). |

<sub>Reviews (2): Last reviewed commit: ["feat(scripts): add poll-livestreams cron..."](https://github.com/schemalabz/opencouncil-tasks/commit/9604085f36a74a503785a6ea862c8a19118441c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41605046)</sub>

<!-- /greptile_comment -->