### PR TITLE
Verify a downloaded livestream recording is complete before transcribing

### DIFF
--- a/src/tasks/pipeline.test.ts
+++ b/src/tasks/pipeline.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { createPipeline, type PipelineDeps } from "./pipeline.js";
 import type { Transcript, TranscriptWithSpeakerIdentification, DiarizationSpeaker } from "../types.js";
 
+// The completeness check probes the downloaded file's duration via ffprobe; stub it
+// so tests drive "complete" vs "partial" without touching the filesystem.
+const { mockGetMediaDurationSeconds } = vi.hoisted(() => ({ mockGetMediaDurationSeconds: vi.fn() }));
+vi.mock("./utils/mediaOperations.js", () => ({
+    getMediaDurationSeconds: mockGetMediaDurationSeconds,
+}));
+
 const fakeDiarization = [{ start: 0, end: 10, speaker: "SPEAKER_00" }];
 const fakeSpeakers: DiarizationSpeaker[] = [{ speaker: "SPEAKER_00", match: null, confidence: {} }];
 const fakeTranscript: Transcript = {
@@ -166,6 +173,32 @@ describe("createPipeline", () => {
         await pipeline(baseRequest, vi.fn());
 
         expect(deps.createMuxAsset).toHaveBeenCalledWith("https://cdn.example.com/video.mp4");
+    });
+
+    it("completeness — rejects and skips downstream work when the download is a partial recording", async () => {
+        mockGetMediaDurationSeconds.mockResolvedValue(1000); // got 1000s of a ~7200s stream
+        const deps = createStubDeps();
+        const pipeline = createPipeline(deps);
+
+        await expect(
+            pipeline({ ...baseRequest, expectedDurationSeconds: 7200 }, vi.fn()),
+        ).rejects.toThrow("INCOMPLETE_RECORDING");
+
+        // Failed before any expensive downstream step
+        expect(deps.downloadYTV).toHaveBeenCalledOnce();
+        expect(deps.diarize).not.toHaveBeenCalled();
+        expect(deps.transcribe).not.toHaveBeenCalled();
+    });
+
+    it("completeness — proceeds when the downloaded duration is within tolerance", async () => {
+        mockGetMediaDurationSeconds.mockResolvedValue(7100); // ~7200s expected, well within tolerance
+        const deps = createStubDeps();
+        const pipeline = createPipeline(deps);
+
+        const result = await pipeline({ ...baseRequest, expectedDurationSeconds: 7200 }, vi.fn());
+
+        expect(result.transcript).toEqual(fakeDiarizedTranscript);
+        expect(deps.diarize).toHaveBeenCalledOnce();
     });
 
     it("data flow — split audio segments are uploaded and passed to transcribe", async () => {

--- a/src/tasks/pipeline.ts
+++ b/src/tasks/pipeline.ts
@@ -10,10 +10,23 @@ import { uploadToSpaces } from "./uploadToSpaces.js";
 import { type UploadFilesArgs } from "./uploadToSpaces.js";
 import { createMuxAsset, deleteMuxAsset, type MuxResult } from "../lib/mux.js";
 import { MAX_TRANSCRIPTION_SEGMENT_DURATION_SECONDS } from "../lib/ScribeTranscribe.js";
+import { getMediaDurationSeconds } from "./utils/mediaOperations.js";
+import fs from "fs";
 import _ from 'underscore';
 import dotenv from "dotenv";
 
 dotenv.config();
+
+/**
+ * Completeness thresholds for a downloaded recording vs its expected (livestream)
+ * duration. A file counts as an incomplete/partial download only when it is BOTH
+ * proportionally short (below COMPLETENESS_RATIO of expected) AND absolutely short
+ * (missing more than MIN_SHORTFALL_SECONDS). The absolute floor avoids false alarms
+ * on the normal small gap between a livestream's wall-clock length and its archived
+ * VOD (trimmed pre-roll, minor reconnect gaps).
+ */
+const COMPLETENESS_RATIO = 0.9;
+const MIN_SHORTFALL_SECONDS = 120;
 
 export type Task<Args, Ret> = (args: Args, onProgress: (stage: string, progressPercent: number) => void) => Promise<Ret>;
 
@@ -35,6 +48,34 @@ export function createPipeline(deps: PipelineDeps): Task<Omit<TranscribeRequest,
         };
 
         const { audioOnly, combined, sourceType } = await deps.downloadYTV(request.youtubeUrl, createProgressHandler("downloading-video"));
+
+        // Verify the recording is complete before doing any expensive downstream work.
+        // Right after a YouTube livestream ends, the archived VOD may still be processing,
+        // so yt-dlp can capture a truncated recording that still passes the >0-bytes check.
+        // If we downloaded something clearly shorter than the livestream's wall-clock length,
+        // drop the partial files (so the next attempt re-downloads instead of reusing the
+        // cached partial) and fail — the caller retries once the VOD has finished processing.
+        if (request.expectedDurationSeconds && request.expectedDurationSeconds > 0) {
+            const expected = request.expectedDurationSeconds;
+            const actualDuration = await getMediaDurationSeconds(combined);
+            const shortfall = expected - actualDuration;
+
+            if (actualDuration < expected * COMPLETENESS_RATIO && shortfall > MIN_SHORTFALL_SECONDS) {
+                for (const file of [combined, audioOnly]) {
+                    try {
+                        if (fs.existsSync(file)) fs.unlinkSync(file);
+                    } catch (cleanupErr) {
+                        console.warn(`Failed to remove partial download ${file}:`, cleanupErr);
+                    }
+                }
+                throw new Error(
+                    `INCOMPLETE_RECORDING: downloaded ${Math.round(actualDuration)}s but expected ~${Math.round(expected)}s ` +
+                    `(VOD likely still processing); dropped partial files so the next attempt re-downloads`
+                );
+            }
+
+            console.log(`Recording completeness OK: ${Math.round(actualDuration)}s vs expected ~${Math.round(expected)}s`);
+        }
 
         // Only upload video if it's not already from our CDN
         const isCdnUrl = sourceType === 'CDN';

--- a/src/tasks/utils/mediaOperations.ts
+++ b/src/tasks/utils/mediaOperations.ts
@@ -7,6 +7,7 @@ import { uploadToSpaces } from "../uploadToSpaces.js";
 import { SplitMediaFileRequest, MediaType, GenerateHighlightRequest, AspectRatio } from "../../types.js";
 
 const execAsync = promisify(cp.exec);
+const execFileAsync = promisify(cp.execFile);
 
 // Create data directory if it doesn't exist
 const dataDir = process.env.DATA_DIR || "./data";
@@ -259,9 +260,15 @@ export async function getVideoResolution(videoPath: string): Promise<{width: num
  */
 export async function getMediaDurationSeconds(filePath: string): Promise<number> {
     const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
-    const command = `${ffprobePath} -v quiet -show_entries format=duration -of csv=p=0 "${filePath}"`;
 
-    const { stdout } = await execAsync(command);
+    // execFile (no shell) so a path containing shell metacharacters is treated as
+    // data, not expanded/executed.
+    const { stdout } = await execFileAsync(ffprobePath, [
+        '-v', 'quiet',
+        '-show_entries', 'format=duration',
+        '-of', 'csv=p=0',
+        filePath,
+    ]);
     const duration = parseFloat(stdout.trim());
 
     if (isNaN(duration) || duration <= 0) {

--- a/src/tasks/utils/mediaOperations.ts
+++ b/src/tasks/utils/mediaOperations.ts
@@ -6,7 +6,6 @@ import { promisify } from "util";
 import { uploadToSpaces } from "../uploadToSpaces.js";
 import { SplitMediaFileRequest, MediaType, GenerateHighlightRequest, AspectRatio } from "../../types.js";
 
-const execAsync = promisify(cp.exec);
 const execFileAsync = promisify(cp.execFile);
 
 // Create data directory if it doesn't exist
@@ -218,11 +217,16 @@ export async function getVideoResolution(videoPath: string): Promise<{width: num
         
         // Resolve ffprobe path: allow override via env, fallback to system ffprobe
         const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
-        
-        // Use ffprobe to get video stream dimensions
-        const command = `${ffprobePath} -v quiet -select_streams v:0 -show_entries stream=width,height -of csv=p=0 "${videoPath}"`;
-        
-        const { stdout, stderr } = await execAsync(command);
+
+        // execFile (no shell) so the video path is passed as an argv value and a path
+        // with shell metacharacters can't be interpreted by a shell.
+        const { stdout, stderr } = await execFileAsync(ffprobePath, [
+            '-v', 'quiet',
+            '-select_streams', 'v:0',
+            '-show_entries', 'stream=width,height',
+            '-of', 'csv=p=0',
+            videoPath,
+        ]);
         
         if (stderr) {
             console.warn(`⚠️ ffprobe stderr: ${stderr}`);

--- a/src/tasks/utils/mediaOperations.ts
+++ b/src/tasks/utils/mediaOperations.ts
@@ -252,6 +252,26 @@ export async function getVideoResolution(videoPath: string): Promise<{width: num
 }
 
 /**
+ * Get a media file's duration in seconds using ffprobe.
+ * Works for both audio and video containers (reads the format-level duration).
+ * @param filePath Path to the media file
+ * @returns Promise<number> Duration in seconds
+ */
+export async function getMediaDurationSeconds(filePath: string): Promise<number> {
+    const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
+    const command = `${ffprobePath} -v quiet -show_entries format=duration -of csv=p=0 "${filePath}"`;
+
+    const { stdout } = await execAsync(command);
+    const duration = parseFloat(stdout.trim());
+
+    if (isNaN(duration) || duration <= 0) {
+        throw new Error(`Invalid media duration from ffprobe: "${stdout.trim()}" for ${filePath}`);
+    }
+
+    return duration;
+}
+
+/**
  * Generate FFmpeg filter for social-9x16 transformation
  * Converts any input aspect ratio to 9:16 output with configurable margins and zoom
  * Now size-agnostic - works with any input dimensions

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,12 @@ export interface TranscribeRequest extends TaskRequest {
     youtubeUrl: string;
     cityLanguage: CityLanguage;
     voiceprints?: Voiceprint[];
+    // Expected length of the recording in seconds (livestream wall-clock:
+    // actualEndTime - actualStartTime). When set, the pipeline verifies the
+    // downloaded media is at least this long; a clearly shorter file means the
+    // VOD was still processing and yt-dlp captured a partial recording, so the
+    // download is dropped and the task fails for the caller to retry later.
+    expectedDurationSeconds?: number;
 }
 
 export type TranscriptWithUtteranceDrifts = Transcript & {


### PR DESCRIPTION
When a council livestream ends, YouTube keeps processing the archived VOD for a while before it's fully available. During that window yt-dlp can pull down a truncated recording, and the only sanity check on the download today is that the file isn't zero bytes, so a partial recording slips through and gets transcribed.

This adds a completeness check to the transcribe pipeline. When the request carries `expectedDurationSeconds` (the livestream's wall-clock length, sent by the main app), the pipeline probes the downloaded file with ffprobe and compares it. If the file is clearly short, below 90% of expected and missing more than two minutes, it deletes the cached mp4 and mp3 and fails the task. Deleting them matters: `downloadYTV` reuses any existing non-empty mp4 by video id, so if we left the partial in place the retry would just pick it straight back up.

Requests without `expectedDurationSeconds`, like manual transcribes or normal (non-livestream) uploads, skip the check, so nothing changes for those.

The retry that makes this useful (grace period plus backoff) lives in the main app, schemalabz/opencouncil#530. On its own this PR is inert until that one ships, since nothing sends `expectedDurationSeconds` yet.

Closes #69.

Tests: two new pipeline cases, one where a partial download is rejected and downstream work is skipped, one where a download within tolerance proceeds. Full suite passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a completeness check before transcribing downloaded livestream recordings. The main changes are:

- Adds optional expected recording duration to transcribe requests.
- Probes downloaded media duration with ffprobe before downstream work.
- Deletes cached partial media files when a recording is clearly too short.
- Uses argv-based ffprobe execution in the media helpers.
- Adds pipeline tests for rejected partial recordings and accepted complete recordings.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/tasks/utils/mediaOperations.ts | Updates ffprobe helpers to use argv-based execution and adds a duration probe helper. |
| src/tasks/pipeline.ts | Checks downloaded media duration before transcription and removes cached partial files when the recording is incomplete. |
| src/types.ts | Adds the optional expected duration field to transcribe requests. |
| src/tasks/pipeline.test.ts | Adds tests for rejecting short recordings and continuing when duration is within tolerance. |

<sub>Reviews (3): Last reviewed commit: ["fix(media): run getVideoResolution ffpro..."](https://github.com/schemalabz/opencouncil-tasks/commit/527028e363782ca87ab9457c9313e90c71418eb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42357590)</sub>

<!-- /greptile_comment -->