### PR TITLE
feat(tasks): promote batch LLM calls to streaming mid-run, with cooperative task cancellation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -731,7 +731,7 @@ program
             };
 
             console.log('Running observability check (one Haiku call through TaskManager)...');
-            await taskManager.runTaskWithCallback(checkTask, {}, callbackUrl, 'observability-check');
+            await taskManager.runTaskWithCallback(checkTask, {}, callbackUrl, 'observability-check').completion;
             await taskManager.finish();
 
             console.log('\n✅ Check task completed. Verify the trace in Langfuse:');
@@ -861,6 +861,84 @@ runsCommand
             console.log(`HTML: ${htmlPath} — open in a browser to review.`);
         } catch (error) {
             console.error('Error comparing runs:', error instanceof Error ? error.message : error);
+            process.exitCode = 1;
+        } finally {
+            server.close();
+        }
+    });
+
+const tasksCommand = program
+    .command('tasks')
+    .description('Inspect and control tasks on a running tasks server (TASKS_SERVER_URL, TASKS_API_TOKEN)');
+
+const tasksServerUrl = () => process.env.TASKS_SERVER_URL || `http://localhost:${process.env.PORT || 3000}`;
+
+async function tasksServerRequest(path: string, method: 'GET' | 'POST' = 'GET'): Promise<any> {
+    const headers: Record<string, string> = {};
+    if (process.env.TASKS_API_TOKEN) headers['Authorization'] = `Bearer ${process.env.TASKS_API_TOKEN}`;
+    let response: Response;
+    try {
+        response = await fetch(`${tasksServerUrl()}${path}`, { method, headers });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`${method} ${tasksServerUrl()}${path} failed: ${msg}`);
+    }
+    const body: any = await response.json().catch(() => ({}));
+    if (!response.ok) {
+        throw new Error(`${method} ${path} → ${response.status}: ${body.error || JSON.stringify(body)}`);
+    }
+    return body;
+}
+
+tasksCommand
+    .command('list')
+    .description('List running and queued tasks')
+    .action(async () => {
+        try {
+            const { running, queued, maxParallelTasks } = await tasksServerRequest('/tasks');
+            if (running.length === 0 && queued.length === 0) {
+                console.log('No running or queued tasks.');
+            }
+            for (const t of running) {
+                const runningFor = Math.round((Date.now() - new Date(t.createdAt).getTime()) / 1000);
+                console.log(`${t.taskId}  ${t.taskType}  ${t.stage} ${t.progressPercent.toFixed(0)}%  llm:${t.llmMode}  running ${runningFor}s`);
+            }
+            for (const t of queued) {
+                console.log(`${t.taskId}  ${t.taskType}  queued`);
+            }
+            console.log(`\n${running.length} running / ${queued.length} queued (max parallel: ${maxParallelTasks})`);
+        } catch (e) {
+            console.error(e instanceof Error ? e.message : e);
+            process.exitCode = 1;
+        } finally {
+            server.close();
+        }
+    });
+
+tasksCommand
+    .command('cancel <taskId>')
+    .description('Cancel a running or queued task (cooperative)')
+    .action(async (taskId: string) => {
+        try {
+            const result = await tasksServerRequest(`/tasks/${taskId}/cancel`, 'POST');
+            console.log(`${result.taskId}: ${result.status}`);
+        } catch (e) {
+            console.error(e instanceof Error ? e.message : e);
+            process.exitCode = 1;
+        } finally {
+            server.close();
+        }
+    });
+
+tasksCommand
+    .command('promote <taskId>')
+    .description("Switch a running task's LLM calls from the Batch API to streaming")
+    .action(async (taskId: string) => {
+        try {
+            const result = await tasksServerRequest(`/tasks/${taskId}/promote`, 'POST');
+            console.log(`${result.taskId}: llmMode=${result.llmMode}`);
+        } catch (e) {
+            console.error(e instanceof Error ? e.message : e);
             process.exitCode = 1;
         } finally {
             server.close();

--- a/src/lib/TaskManager.test.ts
+++ b/src/lib/TaskManager.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TaskManager } from './TaskManager.js';
+import { Task } from '../tasks/pipeline.js';
+import { abortableSleep, getTaskControl, throwIfCancelled } from './taskControl.js';
+
+// Collects the JSON bodies of every callback the manager sends.
+function stubCallbacks(): { payloads: any[] } {
+    const collected = { payloads: [] as any[] };
+    vi.stubGlobal('fetch', vi.fn(async (_url: any, init: any) => {
+        collected.payloads.push(JSON.parse(init.body));
+        return new Response('ok');
+    }));
+    return collected;
+}
+
+// A task that sleeps cooperatively in small steps, observing cancellation.
+const slowTask: Task<{ steps: number }, string> = async (args, onProgress) => {
+    for (let i = 0; i < args.steps; i++) {
+        onProgress(`step-${i}`, (i / args.steps) * 100);
+        await abortableSleep(50, getTaskControl()?.cancel.signal);
+        throwIfCancelled();
+    }
+    return 'done';
+};
+
+describe('TaskManager cancellation', () => {
+
+    beforeEach(() => vi.unstubAllGlobals());
+
+    it('returns a taskId at submission and reports it in updates', async () => {
+        stubCallbacks();
+        const manager = new TaskManager(2);
+        const { taskId, completion } = manager.runTaskWithCallback(slowTask, { steps: 1 }, 'http://cb', 'test');
+        expect(taskId).toMatch(/^task_[0-9a-f]{8}_\d+$/);
+        expect(manager.getTaskUpdates()[0].taskId).toBe(taskId);
+        await completion;
+    });
+
+    it('cancelling a running task sends a cancelled callback and frees the slot', async () => {
+        const callbacks = stubCallbacks();
+        const manager = new TaskManager(2);
+        const { taskId, completion } = manager.runTaskWithCallback(slowTask, { steps: 100 }, 'http://cb', 'test');
+
+        await new Promise(resolve => setTimeout(resolve, 60)); // let it start
+        expect(manager.cancelTask(taskId)).toBe('cancelling');
+        await completion;
+
+        const terminal = callbacks.payloads.at(-1);
+        expect(terminal.status).toBe('cancelled');
+        expect(manager.getTaskUpdates()).toHaveLength(0);
+    });
+
+    it('cancelling a queued task dequeues it and sends a cancelled callback', async () => {
+        const callbacks = stubCallbacks();
+        const manager = new TaskManager(1); // capacity 1 → second task queues
+        const first = manager.runTaskWithCallback(slowTask, { steps: 5 }, 'http://cb1', 'test');
+        const second = manager.runTaskWithCallback(slowTask, { steps: 5 }, 'http://cb2', 'test');
+
+        expect(manager.getQueuedTasksCount()).toBe(1);
+        expect(manager.cancelTask(second.taskId)).toBe('cancelled');
+        expect(manager.getQueuedTasksCount()).toBe(0);
+
+        const cancelledCallback = callbacks.payloads.find(p => p.status === 'cancelled');
+        expect(cancelledCallback).toBeDefined();
+
+        manager.cancelTask(first.taskId);
+        await Promise.all([first.completion, second.completion]);
+    });
+
+    it('cancelTask returns null for unknown ids', () => {
+        stubCallbacks();
+        const manager = new TaskManager(2);
+        expect(manager.cancelTask('task_999')).toBeNull();
+    });
+
+    it('promoteTask flips llmMode to streaming and aborts the promote signal', async () => {
+        stubCallbacks();
+        const manager = new TaskManager(2);
+        let observedMode: string | undefined;
+        let observedPromoteAborted: boolean | undefined;
+        const probeTask: Task<{}, string> = async (_args, _onProgress) => {
+            await abortableSleep(100, getTaskControl()?.promote.signal);
+            observedMode = getTaskControl()?.llmMode;
+            observedPromoteAborted = getTaskControl()?.promote.signal.aborted;
+            return 'ok';
+        };
+        const { taskId, completion } = manager.runTaskWithCallback(probeTask, {}, 'http://cb', 'test');
+        expect(manager.promoteTask(taskId)).toBe(true);
+        await completion;
+        expect(observedMode).toBe('streaming');
+        expect(observedPromoteAborted).toBe(true);
+        expect(manager.promoteTask('task_999')).toBe(false);
+    });
+
+    it('a non-cancellation error still reports status error', async () => {
+        const callbacks = stubCallbacks();
+        const manager = new TaskManager(2);
+        const failingTask: Task<{}, string> = async () => { throw new Error('boom'); };
+        const { completion } = manager.runTaskWithCallback(failingTask, {}, 'http://cb', 'test');
+        await completion;
+        expect(callbacks.payloads.at(-1).status).toBe('error');
+        expect(callbacks.payloads.at(-1).error).toBe('boom');
+    });
+
+    it('a task that only reports progress is cancelled at the onProgress checkpoint', async () => {
+        const callbacks = stubCallbacks();
+        const manager = new TaskManager(2);
+        const progressOnlyTask: Task<{}, string> = async (_args, onProgress) => {
+            for (let i = 0; i < 100; i++) {
+                onProgress(`step-${i}`, i);
+                await new Promise(resolve => setTimeout(resolve, 20));
+            }
+            return 'done';
+        };
+        const { taskId, completion } = manager.runTaskWithCallback(progressOnlyTask, {}, 'http://cb', 'test');
+        await new Promise(resolve => setTimeout(resolve, 30));
+        manager.cancelTask(taskId);
+        await completion;
+        expect(callbacks.payloads.at(-1).status).toBe('cancelled');
+    });
+
+    it('two queued tasks both complete with success callbacks', async () => {
+        const callbacks = stubCallbacks();
+        const manager = new TaskManager(1); // capacity 1 → second task queues
+        const shortTask: Task<{}, string> = async (_args, onProgress) => {
+            onProgress('working', 50);
+            await new Promise(resolve => setTimeout(resolve, 20));
+            return 'done';
+        };
+        const first = manager.runTaskWithCallback(shortTask, {}, 'http://cb1', 'test');
+        const second = manager.runTaskWithCallback(shortTask, {}, 'http://cb2', 'test');
+        await Promise.all([first.completion, second.completion]);
+        const successes = callbacks.payloads.filter(p => p.status === 'success');
+        expect(successes).toHaveLength(2);
+    });
+
+    it('classifies a cancel that surfaces as a wrapped SDK error as cancelled', async () => {
+        const callbacks = stubCallbacks();
+        const manager = new TaskManager(2);
+        const sdkLikeTask: Task<{}, string> = async () => {
+            const signal = getTaskControl()!.cancel.signal;
+            await abortableSleep(5_000, signal);
+            // Simulates the SDK's APIUserAbortError: a plain Error, not TaskCancelledError
+            throw new Error('Request was aborted.');
+        };
+        const { taskId, completion } = manager.runTaskWithCallback(sdkLikeTask, {}, 'http://cb', 'test');
+        await new Promise(resolve => setTimeout(resolve, 20));
+        manager.cancelTask(taskId);
+        await completion;
+        expect(callbacks.payloads.at(-1).status).toBe('cancelled');
+    });
+});

--- a/src/lib/TaskManager.ts
+++ b/src/lib/TaskManager.ts
@@ -1,9 +1,14 @@
 import express from 'express';
+import { randomUUID } from 'node:crypto';
 import { Task } from '../tasks/pipeline.js';
 import { TaskUpdate } from '../types.js';
 import chalk from 'chalk';
 import dotenv from 'dotenv';
 import { runWithTaskTrace } from './observability.js';
+import { LlmMode, TaskCancelledError, TaskControl, newTaskControl, runWithTaskControl } from './taskControl.js';
+
+// Per-process prefix so task IDs never collide across server restarts.
+const INSTANCE_ID = randomUUID().slice(0, 8);
 
 // Task metadata interface
 export interface TaskMetadata {
@@ -27,10 +32,12 @@ type CallbackPayload = TaskUpdate<unknown> & {
     createdAt: Date,
     lastUpdatedAt: Date,
     taskType: string,
+    taskId?: string,
 };
 
 type RunningTask = Omit<CallbackPayload, "result" | "error"> & {
     callbackUrl: string,
+    taskId: string,
 };
 
 // Task queue item with all necessary information to run a task
@@ -41,28 +48,38 @@ type QueuedTask<T, R> = {
     taskType: string;
     createdAt: Date;
     version?: number;
+    taskId: string;
+    onDone?: () => void;
 };
 
-class TaskManager {
+export class TaskManager {
     private runningTasks: Map<string, RunningTask> = new Map();
+    private taskControls: Map<string, TaskControl> = new Map();
     private taskQueue: Array<QueuedTask<any, any>> = [];
     private taskCounter: number = 0;
     private maxParallelTasks: number;
 
-    constructor() {
-        this.maxParallelTasks = parseInt(process.env.MAX_PARALLEL_TASKS || '10', 10);
+    constructor(maxParallelTasks?: number) {
+        this.maxParallelTasks = maxParallelTasks ?? parseInt(process.env.MAX_PARALLEL_TASKS || '10', 10);
         if (isNaN(this.maxParallelTasks)) {
-            this.maxParallelTasks = 10; // Default to 10 if parsing fails
+            this.maxParallelTasks = 10;
             console.warn('Invalid MAX_PARALLEL_TASKS in .env, using default of 10');
         }
     }
 
-    public getTaskUpdates(): RunningTask[] {
-        return Array.from(this.runningTasks.values());
+    public getTaskUpdates(): (RunningTask & { llmMode: LlmMode })[] {
+        return Array.from(this.runningTasks.entries()).map(([taskId, task]) => ({
+            ...task,
+            llmMode: this.taskControls.get(taskId)?.llmMode ?? 'batch',
+        }));
     }
 
     public getQueuedTasksCount(): number {
         return this.taskQueue.length;
+    }
+
+    public getQueuedTaskSummaries(): { taskId: string; taskType: string; createdAt: Date }[] {
+        return this.taskQueue.map(({ taskId, taskType, createdAt }) => ({ taskId, taskType, createdAt }));
     }
 
     public getMaxParallelTasks(): number {
@@ -76,12 +93,11 @@ class TaskManager {
     }
 
     private processQueue(): void {
-        // Process tasks from the queue if we have capacity
         while (this.runningTasks.size < this.maxParallelTasks && this.taskQueue.length > 0) {
             const nextTask = this.taskQueue.shift();
             if (nextTask) {
-                const { task, input, callbackUrl, taskType, version } = nextTask;
-                this.executeTask(task, input, callbackUrl, taskType, version);
+                const { task, input, callbackUrl, taskType, taskId, version, onDone } = nextTask;
+                void this.executeTask(task, input, callbackUrl, taskType, taskId, version).finally(() => onDone?.());
             }
         }
     }
@@ -91,10 +107,12 @@ class TaskManager {
         input: T,
         callbackUrl: string,
         taskType: string,
+        taskId: string,
         version?: number
     ): Promise<void> {
-        const taskId = `task_${++this.taskCounter}`;
         const createdAt = new Date();
+        const control = newTaskControl(taskId);
+        this.taskControls.set(taskId, control);
         try {
             const initialUpdate: RunningTask = {
                 status: "processing",
@@ -104,16 +122,26 @@ class TaskManager {
                 lastUpdatedAt: createdAt,
                 taskType,
                 callbackUrl,
-                version
+                version,
+                taskId,
             };
             this.runningTasks.set(taskId, initialUpdate);
 
-            // Send initial callback immediately
             await this.sendCallback(callbackUrl, initialUpdate);
 
-            const result = await runWithTaskTrace(
+            if (control.cancel.signal.aborted) {
+                throw new TaskCancelledError(`Task ${taskId} cancelled`);
+            }
+
+            const result = await runWithTaskControl(control, () => runWithTaskTrace(
                 { taskType, version, input, callbackUrl },
                 () => task(input, (stage, progressPercent) => {
+                    // Universal cancellation checkpoint: every task reports
+                    // progress, so every task observes cancellation here
+                    // without task-code changes.
+                    if (control.cancel.signal.aborted) {
+                        throw new TaskCancelledError(`Task ${taskId} cancelled`);
+                    }
                     const now = new Date();
                     const update: RunningTask = {
                         status: "processing",
@@ -123,14 +151,15 @@ class TaskManager {
                         lastUpdatedAt: now,
                         taskType,
                         callbackUrl,
-                        version
+                        version,
+                        taskId,
                     };
                     this.runningTasks.set(taskId, update);
                     this.sendCallback(callbackUrl, update);
                 })
-            );
+            ));
 
-            const finalUpdate: TaskUpdate<R> & { createdAt: Date, lastUpdatedAt: Date, taskType: string } = {
+            const finalUpdate: TaskUpdate<R> & { createdAt: Date, lastUpdatedAt: Date, taskType: string, taskId: string } = {
                 status: "success",
                 stage: "finished",
                 progressPercent: 100,
@@ -138,64 +167,115 @@ class TaskManager {
                 createdAt,
                 lastUpdatedAt: new Date(),
                 taskType,
-                version
+                version,
+                taskId,
             };
             await this.sendCallback(callbackUrl, finalUpdate);
         } catch (error: any) {
-            const errorUpdate: TaskUpdate<any> & { createdAt: Date, lastUpdatedAt: Date, taskType: string } = {
-                status: "error",
-                stage: "finished",
+            // A cancel that lands mid-SDK-call surfaces as APIUserAbortError (or
+            // other wrappers) — the aborted signal is the authoritative marker.
+            const cancelled = error instanceof TaskCancelledError || control.cancel.signal.aborted;
+            const errorUpdate: TaskUpdate<any> & { createdAt: Date, lastUpdatedAt: Date, taskType: string, taskId: string } = {
+                status: cancelled ? "cancelled" : "error",
+                stage: cancelled ? "cancelled" : "finished",
                 progressPercent: 100,
-                error: error.message,
+                ...(cancelled ? {} : { error: error.message }),
                 createdAt,
                 lastUpdatedAt: new Date(),
                 taskType,
-                version
+                version,
+                taskId,
             };
             await this.sendCallback(callbackUrl, errorUpdate);
-            console.error('Error in task:', error);
+            if (cancelled) {
+                console.log(`Task ${taskId} (${taskType}) cancelled`);
+            } else {
+                console.error('Error in task:', error);
+            }
         } finally {
             this.runningTasks.delete(taskId);
-            // Process the queue after a task finishes
+            this.taskControls.delete(taskId);
             this.processQueue();
         }
     }
 
-    public async runTaskWithCallback<T, R>(
+    public runTaskWithCallback<T, R>(
         task: Task<T, R>,
         input: T,
         callbackUrl: string,
         taskType: string,
         version?: number
-    ): Promise<void> {
-        // Check if we've reached the maximum number of parallel tasks
+    ): { taskId: string; completion: Promise<void> } {
+        const taskId = `task_${INSTANCE_ID}_${++this.taskCounter}`;
+
         if (this.runningTasks.size >= this.maxParallelTasks) {
-            // Queue the task
+            let onDone!: () => void;
+            const completion = new Promise<void>(resolve => { onDone = resolve; });
             const queuedTask: QueuedTask<T, R> = {
-                task,
-                input,
-                callbackUrl,
-                taskType,
-                createdAt: new Date(),
-                version
+                task, input, callbackUrl, taskType, createdAt: new Date(), version, taskId, onDone,
             };
             this.taskQueue.push(queuedTask);
-            console.log(`Task ${taskType} queued. Current queue size: ${this.taskQueue.length}`);
+            console.log(`Task ${taskType} queued as ${taskId}. Current queue size: ${this.taskQueue.length}`);
 
-            // Send a callback to inform that the task is queued
-            await this.sendCallback(callbackUrl, {
+            void this.sendCallback(callbackUrl, {
                 status: "processing",
                 stage: "queued",
                 progressPercent: 0,
                 createdAt: queuedTask.createdAt,
                 lastUpdatedAt: queuedTask.createdAt,
                 taskType,
-                version
+                version,
+                taskId,
             });
-        } else {
-            // Execute the task immediately
-            await this.executeTask(task, input, callbackUrl, taskType, version);
+            return { taskId, completion };
         }
+
+        return { taskId, completion: this.executeTask(task, input, callbackUrl, taskType, taskId, version) };
+    }
+
+    /**
+     * Cancel a task. Queued tasks are removed immediately ('cancelled');
+     * running tasks get their signal aborted and finish cooperatively at the
+     * next checkpoint ('cancelling'). Returns null for unknown/finished ids.
+     */
+    public cancelTask(taskId: string): 'cancelling' | 'cancelled' | null {
+        const queuedIndex = this.taskQueue.findIndex(t => t.taskId === taskId);
+        if (queuedIndex !== -1) {
+            const [queued] = this.taskQueue.splice(queuedIndex, 1);
+            // Resolve completion only after the callback delivery attempt, matching
+            // the running-task path where the terminal callback is awaited before
+            // the task promise settles.
+            void this.sendCallback(queued.callbackUrl, {
+                status: "cancelled",
+                stage: "cancelled",
+                progressPercent: 0,
+                createdAt: queued.createdAt,
+                lastUpdatedAt: new Date(),
+                taskType: queued.taskType,
+                version: queued.version,
+                taskId,
+            }).finally(() => queued.onDone?.());
+            return 'cancelled';
+        }
+        const control = this.taskControls.get(taskId);
+        if (control) {
+            control.cancel.abort();
+            return 'cancelling';
+        }
+        return null;
+    }
+
+    /**
+     * Switch a running task's LLM calls to streaming mode: future aiChat
+     * calls skip the Batch API, and an in-flight batch poll wakes up, cancels
+     * the Anthropic batch, and re-issues via streaming. Idempotent.
+     */
+    public promoteTask(taskId: string): boolean {
+        const control = this.taskControls.get(taskId);
+        if (!control) return false;
+        control.llmMode = 'streaming';
+        control.promote.abort();
+        return true;
     }
 
     /**
@@ -241,12 +321,11 @@ class TaskManager {
         return handler;
     }
 
-
     public serveTask<REQ, RES>(task: Task<REQ, RES>, version?: number) {
         return (req: express.Request<{}, {}, REQ & { callbackUrl: string }>, res: express.Response) => {
             let taskType = req.path.substring(1);
 
-            this.runTaskWithCallback(
+            const { taskId } = this.runTaskWithCallback(
                 task,
                 req.body,
                 req.body.callbackUrl,
@@ -254,13 +333,11 @@ class TaskManager {
                 version
             );
 
-            const queueSize = this.taskQueue.length;
-            const runningTasksCount = this.runningTasks.size;
-
             res.status(202).json({
                 message: 'Task started',
-                queueSize,
-                runningTasks: runningTasksCount,
+                taskId,
+                queueSize: this.taskQueue.length,
+                runningTasks: this.runningTasks.size,
                 maxParallelTasks: this.maxParallelTasks
             });
         }

--- a/src/lib/ai.test.ts
+++ b/src/lib/ai.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import Anthropic from '@anthropic-ai/sdk';
-import { classifyTransientError, formatApiError, addUsage, NO_USAGE, continuationPrompt, cutToLineBoundary } from './ai.js';
+import { classifyTransientError, formatApiError, addUsage, NO_USAGE, continuationPrompt, cutToLineBoundary, BatchPromotedError, executeBatch } from './ai.js';
+import { TaskCancelledError, newTaskControl, runWithTaskControl } from './taskControl.js';
 
 // ===========================================================================
 // cutToLineBoundary — truncated partials stitch at line boundaries so the
@@ -174,5 +175,85 @@ describe('addUsage', () => {
 
         expect(leftAssoc.input_tokens).toBe(rightAssoc.input_tokens);
         expect(leftAssoc.output_tokens).toBe(rightAssoc.output_tokens);
+    });
+});
+
+// ===========================================================================
+// executeBatch — cancellation and promotion against a fake Anthropic client
+// ===========================================================================
+
+const FAKE_MESSAGE = {
+    content: [{ type: 'text', text: 'hello' }],
+    stop_reason: 'end_turn',
+    usage: NO_USAGE,
+};
+
+const FAKE_PARAMS = { model: 'test', max_tokens: 10, system: 's', messages: [] } as any;
+
+function fakeBatchClient(overrides: Partial<Record<'create' | 'retrieve' | 'cancel' | 'results', any>> = {}) {
+    const batches = {
+        create: vi.fn(async () => ({ id: 'msgbatch_test', created_at: new Date().toISOString() })),
+        retrieve: vi.fn(async () => ({
+            id: 'msgbatch_test', processing_status: 'ended', created_at: new Date().toISOString(),
+        request_counts: { processing: 0, succeeded: 1, errored: 0, canceled: 0, expired: 0 },
+        })),
+        cancel: vi.fn(async () => ({ id: 'msgbatch_test', processing_status: 'canceling' })),
+        results: vi.fn(async () => (async function* () {
+            yield { custom_id: 'request-1', result: { type: 'succeeded', message: FAKE_MESSAGE } };
+        })()),
+        ...overrides,
+    };
+    return { client: { messages: { batches } } as any, batches };
+}
+
+describe('executeBatch cancellation & promotion', () => {
+
+    it('cancel: cancels the Anthropic batch and throws TaskCancelledError', async () => {
+        const { client, batches } = fakeBatchClient();
+        const control = newTaskControl('task_1');
+        control.cancel.abort(); // pre-aborted → poll wakes immediately
+
+        await expect(
+            runWithTaskControl(control, () => executeBatch(FAKE_PARAMS, {}, client))
+        ).rejects.toThrow(TaskCancelledError);
+        expect(batches.cancel).toHaveBeenCalledWith('msgbatch_test');
+    });
+
+    it('promote, cancel wins: throws BatchPromotedError so the caller retries via streaming', async () => {
+        const { client, batches } = fakeBatchClient({
+            results: vi.fn(async () => (async function* () {
+                yield { custom_id: 'request-1', result: { type: 'canceled' } };
+            })()),
+        });
+        const control = newTaskControl('task_2');
+        control.promote.abort();
+        control.llmMode = 'streaming';
+
+        await expect(
+            runWithTaskControl(control, () => executeBatch(FAKE_PARAMS, {}, client))
+        ).rejects.toThrow(BatchPromotedError);
+        expect(batches.cancel).toHaveBeenCalledWith('msgbatch_test');
+    });
+
+    it('promote, request already succeeded: returns the paid result instead of retrying', async () => {
+        const { client } = fakeBatchClient(); // default results yield 'succeeded'
+        const control = newTaskControl('task_3');
+        control.promote.abort();
+        control.llmMode = 'streaming';
+
+        const message = await runWithTaskControl(control, () => executeBatch(FAKE_PARAMS, {}, client));
+        expect(message).toEqual(FAKE_MESSAGE);
+    });
+
+    it('completes normally without any task control (CLI behavior)', async () => {
+        vi.useFakeTimers();
+        try {
+            const { client } = fakeBatchClient();
+            const pending = executeBatch(FAKE_PARAMS, {}, client);
+            await vi.advanceTimersByTimeAsync(60_000);
+            expect(await pending).toEqual(FAKE_MESSAGE);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { promises as fs } from 'fs';
 import { observeGeneration, GenerationHandle } from './observability.js';
+import { TaskCancelledError, abortableSleep, getTaskControl, throwIfCancelled } from './taskControl.js';
 
 dotenv.config();
 
@@ -47,8 +48,6 @@ export function formatUsage(usage: Anthropic.Messages.Usage): string {
 }
 
 export const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const logFilePath = path.join(process.env.LOG_DIR || process.cwd(), 'ai.log');
 export async function logToFile(message: string, data?: any) {
@@ -161,7 +160,8 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
                     const now = new Date();
                     const sleepTime = resetTime.getTime() - now.getTime() + 1000;
                     console.log(`Rate limit hit, sleeping until ${resetTime.toISOString()} (${sleepTime}ms)`);
-                    await sleep(sleepTime);
+                    await abortableSleep(sleepTime, getTaskControl()?.cancel.signal);
+                    throwIfCancelled();
                     continue;
                 }
             }
@@ -171,7 +171,8 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
                 transientRetries++;
                 const backoffMs = transientRetries * BACKOFF_BASE_MS[errorKind];
                 console.log(`Transient ${errorKind} error (attempt ${transientRetries}/${MAX_TRANSIENT_RETRIES}), retrying in ${backoffMs}ms...`);
-                await sleep(backoffMs);
+                await abortableSleep(backoffMs, getTaskControl()?.cancel.signal);
+                throwIfCancelled();
                 continue;
             }
             throw e;
@@ -180,9 +181,27 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 const BATCH_POLL_INTERVAL_MS = 60_000; // 60s between polls
+const BATCH_CANCEL_POLL_INTERVAL_MS = 5_000; // faster polls while a cancel drains
 
-async function executeBatch(requestParams: Anthropic.Messages.MessageCreateParamsNonStreaming, requestOptions: Anthropic.RequestOptions): Promise<Anthropic.Messages.Message> {
-    const batch = await anthropic.messages.batches.create({
+/** Thrown when a batch request was cancelled for promotion; the caller re-issues via streaming. */
+export class BatchPromotedError extends Error {
+    constructor() {
+        super('Batch request cancelled for promotion to streaming');
+        this.name = 'BatchPromotedError';
+    }
+}
+
+export async function executeBatch(
+    requestParams: Anthropic.Messages.MessageCreateParamsNonStreaming,
+    requestOptions: Anthropic.RequestOptions,
+    client: Anthropic = anthropic,
+): Promise<Anthropic.Messages.Message> {
+    const control = getTaskControl();
+    const cancelSignal = control?.cancel.signal;
+    const promoteSignal = control?.promote.signal;
+    const wakeSignal = cancelSignal && promoteSignal ? AbortSignal.any([cancelSignal, promoteSignal]) : undefined;
+
+    const batch = await client.messages.batches.create({
         requests: [{
             custom_id: 'request-1',
             params: requestParams,
@@ -192,14 +211,22 @@ async function executeBatch(requestParams: Anthropic.Messages.MessageCreateParam
     console.log(`Batch created: ${batch.id}, polling for result...`);
 
     while (true) {
-        await sleep(BATCH_POLL_INTERVAL_MS);
+        await abortableSleep(BATCH_POLL_INTERVAL_MS, wakeSignal);
 
-        const status = await anthropic.messages.batches.retrieve(batch.id);
+        if (cancelSignal?.aborted) {
+            await cancelBatchQuietly(client, batch.id);
+            throw new TaskCancelledError(`Batch ${batch.id} cancelled with its task`);
+        }
+        if (promoteSignal?.aborted) {
+            return await resolvePromotedBatch(client, batch.id, cancelSignal);
+        }
+
+        const status = await client.messages.batches.retrieve(batch.id);
         const elapsed = Math.round((Date.now() - new Date(status.created_at).getTime()) / 1000);
         console.log(`Batch ${batch.id}: ${status.processing_status} (${elapsed}s elapsed, ${status.request_counts.processing} processing, ${status.request_counts.succeeded} succeeded)`);
 
         if (status.processing_status === 'ended') {
-            const results = await anthropic.messages.batches.results(batch.id);
+            const results = await client.messages.batches.results(batch.id);
             for await (const result of results) {
                 if (result.custom_id === 'request-1') {
                     if (result.result.type === 'succeeded') {
@@ -217,6 +244,45 @@ async function executeBatch(requestParams: Anthropic.Messages.MessageCreateParam
             throw new Error('Batch completed but no result found for request-1');
         }
     }
+}
+
+async function cancelBatchQuietly(client: Anthropic, batchId: string): Promise<void> {
+    try {
+        await client.messages.batches.cancel(batchId);
+    } catch (e) {
+        console.warn(`Failed to cancel batch ${batchId}: ${e instanceof Error ? e.message : e}`);
+    }
+}
+
+/**
+ * Promotion: cancel the batch, wait for it to end, then resolve the race —
+ * a request that finished before the cancel landed is already paid for
+ * (batch rates), so use its result; otherwise tell the caller to re-issue
+ * via streaming.
+ */
+async function resolvePromotedBatch(
+    client: Anthropic,
+    batchId: string,
+    cancelSignal: AbortSignal | undefined,
+): Promise<Anthropic.Messages.Message> {
+    console.log(`Batch ${batchId}: promotion requested, cancelling batch...`);
+    await cancelBatchQuietly(client, batchId);
+
+    while (true) {
+        const status = await client.messages.batches.retrieve(batchId);
+        if (status.processing_status === 'ended') break;
+        await abortableSleep(BATCH_CANCEL_POLL_INTERVAL_MS, cancelSignal);
+        if (cancelSignal?.aborted) throw new TaskCancelledError(`Batch ${batchId} cancelled with its task`);
+    }
+
+    const results = await client.messages.batches.results(batchId);
+    for await (const result of results) {
+        if (result.custom_id === 'request-1' && result.result.type === 'succeeded') {
+            console.log(`Batch ${batchId}: request completed before cancel landed — using the paid result`);
+            return result.result.message;
+        }
+    }
+    throw new BatchPromotedError();
 }
 
 /**
@@ -243,8 +309,10 @@ export function continuationPrompt(partial: string): string {
 export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystemResponse, continueFromPartial, prependToResponse, documentBase64, parseJson = true, maxTokens: maxTokensParam, tools, outputFormat, cacheSystemPrompt = false, batchFirst = false, label }: AiChatOptions): Promise<ResultWithUsage<T>> {
     const maxTokens = maxTokensParam ?? 64000;
     let generation: GenerationHandle | undefined;
+    const control = getTaskControl();
     try {
         console.log(`Sending message to claude${batchFirst ? ' (batch-first)' : ''}...`);
+        throwIfCancelled();
         let messages: Anthropic.Messages.MessageParam[] = [];
         if (documentBase64) {
             messages.push({
@@ -315,21 +383,40 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
             metadata: { batchFirst, cacheSystemPrompt, maxTokens, hasTools: Boolean(tools), hasDocument: Boolean(documentBase64) },
         });
 
-        // Prepare request options with beta headers if needed
-        const requestOptions: Anthropic.RequestOptions = outputFormat ? {
-            headers: {
-                'anthropic-beta': 'structured-outputs-2025-11-13'
-            }
-        } : {};
+        // Prepare request options with beta headers if needed, plus cancel signal
+        const requestOptions: Anthropic.RequestOptions = {
+            ...(outputFormat ? { headers: { 'anthropic-beta': 'structured-outputs-2025-11-13' } } : {}),
+            ...(control ? { signal: control.cancel.signal } : {}),
+        };
 
         // Stream with retry, fall back to Batches API if all retries exhausted.
         // Streaming is fast (seconds) but fragile on long requests. The Batches API
         // is slower (minutes of queue time) but immune to connection drops.
         // batchFirst: skip streaming entirely, go direct to Batches API (300K output limit).
+        // A promoted task (llmMode 'streaming') skips the Batch API for the rest of its run.
+        const llmMode = control?.llmMode ?? 'batch';
+        const useBatch = batchFirst && llmMode === 'batch';
         let response: Anthropic.Messages.Message;
-        let usedBatch = batchFirst;
-        if (batchFirst) {
-            response = await executeBatch(requestParams, requestOptions);
+        let usedBatch = useBatch;
+        // Distinguishes "promoted out of batch mid-call" from an ordinary
+        // streaming call (both end with batchMode:false) in the Langfuse trace.
+        let promoted = false;
+        if (useBatch) {
+            try {
+                response = await executeBatch(requestParams, requestOptions);
+            } catch (e) {
+                if (e instanceof BatchPromotedError) {
+                    console.log(`Batch promoted: re-issuing request via streaming...`);
+                    response = await withRetry(async () => {
+                        const stream = anthropic.messages.stream(requestParams, requestOptions);
+                        return stream.finalMessage();
+                    });
+                    usedBatch = false;
+                    promoted = true;
+                } else {
+                    throw e;
+                }
+            }
         } else {
             try {
                 response = await withRetry(async () => {
@@ -337,7 +424,10 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
                     return stream.finalMessage();
                 });
             } catch (e) {
-                if (classifyTransientError(e)) {
+                // After promotion, the batch fallback would re-enter the queue the
+                // operator just escaped (and the aborted promote signal would bounce
+                // it straight back out) — so only fall back while in batch mode.
+                if (classifyTransientError(e) && control?.llmMode !== 'streaming') {
                     console.log(`Streaming failed after retries, falling back to batch mode...`);
                     response = await executeBatch(requestParams, requestOptions);
                     usedBatch = true;
@@ -368,7 +458,7 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
         generation.end({
             output: responseText,
             usage: response.usage,
-            metadata: { batchMode: usedBatch, stopReason: response.stop_reason },
+            metadata: { batchMode: usedBatch, ...(promoted && { promoted: true }), stopReason: response.stop_reason },
         });
 
         if (response.stop_reason === "max_tokens") {
@@ -407,7 +497,7 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
                 result: response2.result,
                 maxTokens,
                 resolvedModel,
-                batchMode: batchFirst
+                batchMode: usedBatch
             }
         }
 
@@ -443,11 +533,18 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
             maxTokens,
             response: response,
             resolvedModel,
-            batchMode: batchFirst
+            batchMode: usedBatch
         };
     } catch (e) {
-        generation?.error(e instanceof Error ? e.message : String(e));
-        console.error(`Error in aiChat: ${e}`);
+        // A cancel that aborts the SDK mid-call surfaces as APIUserAbortError,
+        // not TaskCancelledError — convert it so Langfuse traces read "cancelled"
+        // and the error chain stays meaningful downstream.
+        let err = e;
+        if (control?.cancel.signal.aborted && !(e instanceof TaskCancelledError)) {
+            err = new TaskCancelledError(`Task cancelled during LLM call`);
+        }
+        generation?.error(err instanceof Error ? err.message : String(err));
+        console.error(`Error in aiChat: ${err}`);
         // Log full error details for stream terminations to aid reproduction
         // (see https://github.com/anthropics/anthropic-sdk-typescript/issues/774)
         if (e instanceof Error && (e as any).cause) {
@@ -463,7 +560,7 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
             cause: e instanceof Error ? (e as any).cause : undefined,
             stack: e instanceof Error ? e.stack : undefined,
         });
-        throw formatApiError(e);
+        throw formatApiError(err);
     }
 }
 

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import Anthropic from '@anthropic-ai/sdk';
 import dotenv from 'dotenv';
 import { extractMeetingId } from '../utils.js';
+import { TaskCancelledError, getTaskControl } from './taskControl.js';
 
 dotenv.config();
 
@@ -160,11 +161,22 @@ export async function runWithTaskTrace<R>(options: TaskTraceOptions, fn: () => P
         });
         return result;
     } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // A cancelled task surfaces as TaskCancelledError — or, if the cancel
+        // landed mid-SDK-call, a wrapped abort, so the aborted signal is the
+        // authoritative marker (same discriminator as TaskManager). Tag it
+        // distinctly so cancellations are filterable and don't read as
+        // genuine failures in runs list / error dashboards.
+        const cancelled = error instanceof TaskCancelledError || Boolean(getTaskControl()?.cancel.signal.aborted);
         trace.update({
-            output: { error: error instanceof Error ? error.message : String(error) },
-            tags: [...tags, 'status:error', ...compositePromptTag(context.promptHashes)],
+            output: { error: message },
+            tags: [...tags, cancelled ? 'status:cancelled' : 'status:error', ...compositePromptTag(context.promptHashes)],
         });
-        trace.event({ name: 'task-error', level: 'ERROR', statusMessage: error instanceof Error ? error.message : String(error) });
+        trace.event({
+            name: cancelled ? 'task-cancelled' : 'task-error',
+            level: cancelled ? 'WARNING' : 'ERROR',
+            statusMessage: message,
+        });
         throw error;
     } finally {
         await langfuse.flushAsync().catch((e) => console.error('Langfuse flush failed:', e));

--- a/src/lib/swaggerGenerator.ts
+++ b/src/lib/swaggerGenerator.ts
@@ -48,7 +48,7 @@ export function generateSwaggerPaths(): Record<string, any> {
     paths['/tasks'] = {
         get: {
             summary: 'Running tasks',
-            description: 'List currently running and queued tasks with their status, progress, and duration',
+            description: 'List currently running and queued tasks with their status and progress',
             tags: ['System'],
             security: [{ bearerAuth: [] }],
             responses: {
@@ -64,22 +64,93 @@ export function generateSwaggerPaths(): Record<string, any> {
                                         items: {
                                             type: 'object',
                                             properties: {
+                                                taskId: { type: 'string', example: 'task_ab12cd34_1' },
                                                 taskType: { type: 'string' },
                                                 status: { type: 'string' },
                                                 stage: { type: 'string', nullable: true },
                                                 progressPercent: { type: 'number', nullable: true },
-                                                duration: { type: 'number', description: 'Duration in seconds' },
-                                                callbackUrl: { type: 'string' }
+                                                createdAt: { type: 'string', format: 'date-time' },
+                                                lastUpdatedAt: { type: 'string', format: 'date-time' },
+                                                callbackUrl: { type: 'string' },
+                                                version: { type: 'number', nullable: true },
+                                                llmMode: { type: 'string', nullable: true }
                                             }
                                         }
                                     },
-                                    queued: { type: 'number' },
+                                    queued: {
+                                        type: 'array',
+                                        items: {
+                                            type: 'object',
+                                            properties: {
+                                                taskId: { type: 'string' },
+                                                taskType: { type: 'string' },
+                                                createdAt: { type: 'string', format: 'date-time' }
+                                            }
+                                        }
+                                    },
                                     maxParallelTasks: { type: 'number' }
                                 }
                             }
                         }
                     }
-                }
+                },
+                '401': { description: 'Unauthorized - Invalid or missing token' }
+            }
+        }
+    };
+
+    paths['/tasks/{taskId}/cancel'] = {
+        post: {
+            summary: 'Cancel a task',
+            description: 'Cancel a running or queued task (cooperative: running tasks stop at the next checkpoint)',
+            tags: ['System'],
+            security: [{ bearerAuth: [] }],
+            parameters: [{ name: 'taskId', in: 'path', required: true, schema: { type: 'string' } }],
+            responses: {
+                '200': {
+                    description: 'Task cancellation initiated',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'object',
+                                properties: {
+                                    taskId: { type: 'string' },
+                                    status: { type: 'string', enum: ['cancelling', 'cancelled'] }
+                                }
+                            }
+                        }
+                    }
+                },
+                '401': { description: 'Unauthorized - Invalid or missing token' },
+                '404': { description: 'Task not found' }
+            }
+        }
+    };
+
+    paths['/tasks/{taskId}/promote'] = {
+        post: {
+            summary: 'Promote task to streaming',
+            description: "Switch a running task's LLM calls from the Batch API to streaming",
+            tags: ['System'],
+            security: [{ bearerAuth: [] }],
+            parameters: [{ name: 'taskId', in: 'path', required: true, schema: { type: 'string' } }],
+            responses: {
+                '200': {
+                    description: 'Task promoted to streaming',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'object',
+                                properties: {
+                                    taskId: { type: 'string' },
+                                    llmMode: { type: 'string', enum: ['streaming'] }
+                                }
+                            }
+                        }
+                    }
+                },
+                '401': { description: 'Unauthorized - Invalid or missing token' },
+                '404': { description: 'Task not found' }
             }
         }
     };
@@ -117,6 +188,7 @@ export function generateSwaggerPaths(): Record<string, any> {
                                     type: 'object',
                                     properties: {
                                         message: { type: 'string', example: 'Task started' },
+                                        taskId: { type: 'string', example: 'task_1a2b3c4d_1' },
                                         queueSize: { type: 'number' },
                                         runningTasks: { type: 'number' },
                                         maxParallelTasks: { type: 'number' }

--- a/src/lib/taskControl.test.ts
+++ b/src/lib/taskControl.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+    TaskCancelledError,
+    abortableSleep,
+    getTaskControl,
+    newTaskControl,
+    runWithTaskControl,
+    throwIfCancelled,
+} from './taskControl.js';
+
+describe('taskControl context', () => {
+
+    it('getTaskControl returns undefined outside a task run (CLI/test behavior)', () => {
+        expect(getTaskControl()).toBeUndefined();
+    });
+
+    it('propagates the control through async boundaries', async () => {
+        const control = newTaskControl('task_1');
+        await runWithTaskControl(control, async () => {
+            await new Promise(resolve => setTimeout(resolve, 1));
+            expect(getTaskControl()).toBe(control);
+            expect(getTaskControl()!.taskId).toBe('task_1');
+        });
+    });
+
+    it('throwIfCancelled is a no-op when not cancelled or outside a task', () => {
+        expect(() => throwIfCancelled()).not.toThrow();
+    });
+
+    it('throwIfCancelled throws TaskCancelledError after cancel aborts', async () => {
+        const control = newTaskControl('task_2');
+        control.cancel.abort();
+        await runWithTaskControl(control, async () => {
+            expect(() => throwIfCancelled()).toThrow(TaskCancelledError);
+        });
+    });
+
+    it('throwIfCancelled is a no-op inside a run that has not been cancelled', async () => {
+        const control = newTaskControl('task_3');
+        await runWithTaskControl(control, async () => {
+            expect(() => throwIfCancelled()).not.toThrow();
+        });
+    });
+});
+
+describe('abortableSleep', () => {
+
+    it('resolves early when the signal aborts mid-sleep', async () => {
+        const controller = new AbortController();
+        const start = Date.now();
+        const sleep = abortableSleep(10_000, controller.signal);
+        controller.abort();
+        await sleep;
+        expect(Date.now() - start).toBeLessThan(1000);
+    });
+
+    it('resolves immediately for an already-aborted signal', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        await abortableSleep(10_000, controller.signal); // must not hang
+    });
+
+    it('sleeps normally without a signal', async () => {
+        const start = Date.now();
+        await abortableSleep(20);
+        expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+    });
+});

--- a/src/lib/taskControl.ts
+++ b/src/lib/taskControl.ts
@@ -1,0 +1,68 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Cooperative cancellation & LLM-mode control for a running task.
+ *
+ * TaskManager creates one TaskControl per task and establishes it via
+ * AsyncLocalStorage (same pattern as runWithTaskTrace), so shared primitives
+ * (ai.ts poll loops, SDK calls) can observe cancellation without any
+ * parameter threading. Outside a managed task run (CLI, tests) there is no
+ * store and every accessor degrades to a no-op.
+ */
+
+export class TaskCancelledError extends Error {
+    constructor(message = 'Task cancelled') {
+        super(message);
+        this.name = 'TaskCancelledError';
+    }
+}
+
+export type LlmMode = 'batch' | 'streaming';
+
+export type TaskControl = {
+    taskId: string;
+    /** Aborted when the task is cancelled — terminal. */
+    cancel: AbortController;
+    /** Aborted when the task is promoted out of the Batch API — wakes the poll loop. */
+    promote: AbortController;
+    /** Once 'streaming', aiChat skips the Batch API for the rest of the task. */
+    llmMode: LlmMode;
+};
+
+const storage = new AsyncLocalStorage<TaskControl>();
+
+export function newTaskControl(taskId: string): TaskControl {
+    return { taskId, cancel: new AbortController(), promote: new AbortController(), llmMode: 'batch' };
+}
+
+export function runWithTaskControl<R>(control: TaskControl, fn: () => Promise<R>): Promise<R> {
+    return storage.run(control, fn);
+}
+
+export function getTaskControl(): TaskControl | undefined {
+    return storage.getStore();
+}
+
+export function throwIfCancelled(): void {
+    const control = getTaskControl();
+    if (control?.cancel.signal.aborted) {
+        throw new TaskCancelledError(`Task ${control.taskId} cancelled`);
+    }
+}
+
+/**
+ * Sleep that wakes early (resolves, does not reject) when the signal aborts.
+ * Callers decide what an early wake means — see executeBatch.
+ */
+export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise(resolve => {
+        if (signal?.aborted) return resolve();
+        const done = () => {
+            signal?.removeEventListener('abort', done);
+            clearTimeout(timer);
+            resolve();
+        };
+        const timer = setTimeout(done, ms);
+        signal?.addEventListener('abort', done, { once: true });
+    });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { processAgenda } from './tasks/processAgenda.js';
 import { generateVoiceprint } from './tasks/generateVoiceprint.js';
 import { generateHighlight } from './tasks/generateHighlight.js';
 import { pollDecisions } from './tasks/pollDecisions.js';
+import { devSlowTask } from './tasks/devSlowTask.js';
 import devRouter from './routes/dev.js';
 import uploadRouter from './routes/upload.js';
 import swaggerUi from 'swagger-ui-express';
@@ -57,7 +58,6 @@ app.use(authMiddleware);
 // PUBLIC ENDPOINTS (No Authentication Required)
 // ============================================================================
 
-// Health check endpoint with version information and service status
 app.get('/health', async (req: express.Request, res: express.Response<HealthResponse>) => {
     const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
     const services: { [key: string]: any } = {};
@@ -94,20 +94,36 @@ app.get('/health', async (req: express.Request, res: express.Response<HealthResp
     });
 });
 
+// ============================================================================
+// TASK CONTROL ENDPOINTS (Authentication Required)
+// ============================================================================
+
+// List all running and queued tasks with their current state
 app.get('/tasks', (req, res) => {
-    const running = taskManager.getTaskUpdates().map(t => ({
-        taskType: t.taskType,
-        status: t.status,
-        stage: t.stage,
-        progressPercent: t.progressPercent,
-        duration: Math.floor((Date.now() - t.createdAt.getTime()) / 1000),
-        callbackUrl: t.callbackUrl,
-    }));
     res.json({
-        running,
-        queued: taskManager.getQueuedTasksCount(),
+        running: taskManager.getTaskUpdates(),
+        queued: taskManager.getQueuedTaskSummaries(),
         maxParallelTasks: taskManager.getMaxParallelTasks(),
     });
+});
+
+// Cancel a running or queued task (cooperative: running tasks finish at the next checkpoint)
+app.post('/tasks/:taskId/cancel', (req, res) => {
+    const outcome = taskManager.cancelTask(req.params.taskId);
+    if (!outcome) {
+        res.status(404).json({ error: `No running or queued task ${req.params.taskId}` });
+        return;
+    }
+    res.json({ taskId: req.params.taskId, status: outcome });
+});
+
+// Switch a running task's LLM calls from the Batch API to streaming
+app.post('/tasks/:taskId/promote', (req, res) => {
+    if (!taskManager.promoteTask(req.params.taskId)) {
+        res.status(404).json({ error: `No running task ${req.params.taskId}` });
+        return;
+    }
+    res.json({ taskId: req.params.taskId, llmMode: 'streaming' });
 });
 
 // ============================================================================
@@ -177,6 +193,14 @@ app.post('/pollDecisions', taskManager.registerTask(pollDecisions, {
   description: 'Fetch decisions from the Greek Government Transparency portal, match them to meeting subjects, and extract structured data (excerpt, attendance, votes) from matched PDFs',
   version: 1,
 }));
+
+if (process.env.NODE_ENV !== 'production') {
+    app.post('/dev/slowTask', taskManager.registerTask(devSlowTask, {
+        summary: 'Dev-only slow task for testing cancellation and batch promotion',
+        description: 'Sleeps cooperatively for iterations×sleepMs, optionally makes one tiny batch-first LLM call. Not registered in production.',
+        tags: ['dev'],
+    }));
+}
 
 // Resolve task paths from Express routes, then load API Documentation
 taskManager.resolvePathsFromApp(app);

--- a/src/tasks/devSlowTask.ts
+++ b/src/tasks/devSlowTask.ts
@@ -1,0 +1,49 @@
+import { Task } from './pipeline.js';
+import { abortableSleep, getTaskControl, throwIfCancelled } from '../lib/taskControl.js';
+import { HAIKU_MODEL, aiChat } from '../lib/ai.js';
+
+export type DevSlowTaskArgs = {
+    iterations?: number;   // default 30
+    sleepMs?: number;      // default 2000
+    llmBatchCall?: boolean; // make one real batch-first aiChat call at the end
+};
+
+export type DevSlowTaskResult = {
+    completedIterations: number;
+    llmResult?: string;
+    llmMode?: string;
+};
+
+/**
+ * Dev-only canary for exercising cancellation and batch promotion end-to-end
+ * without real workloads: sleeps cooperatively, and optionally makes one tiny
+ * real Batch API call that can be promoted to streaming mid-flight.
+ */
+export const devSlowTask: Task<DevSlowTaskArgs, DevSlowTaskResult> = async (args, onProgress) => {
+    const iterations = args.iterations ?? 30;
+    const sleepMs = args.sleepMs ?? 2000;
+
+    for (let i = 0; i < iterations; i++) {
+        onProgress('sleeping', Math.round((i / iterations) * 90));
+        await abortableSleep(sleepMs, getTaskControl()?.cancel.signal);
+        throwIfCancelled();
+    }
+
+    let llmResult: string | undefined;
+    if (args.llmBatchCall) {
+        onProgress('llm', 90);
+        const response = await aiChat<string>({
+            model: HAIKU_MODEL,
+            systemPrompt: 'You are terse.',
+            userPrompt: 'Say hello in Greek.',
+            parseJson: false,
+            maxTokens: 100,
+            batchFirst: true,
+            label: 'devSlowTask',
+        });
+        llmResult = response.result;
+    }
+
+    onProgress('finished', 100);
+    return { completedIterations: iterations, llmResult, llmMode: getTaskControl()?.llmMode };
+};

--- a/src/tasks/downloadYTV.ts
+++ b/src/tasks/downloadYTV.ts
@@ -865,7 +865,16 @@ async function downloadWithYtDlp(
                     lastProgressLog = now;
                     console.log(`[yt-dlp] ${videoId}: ${pct.toFixed(0)}% (${formatBytes(p.downloaded)} / ${formatBytes(p.total)})`);
                 }
-                onProgress('yt-dlp', pct);
+                // onProgress may throw TaskCancelledError (universal cancellation
+                // checkpoint). Swallow it here: this callback runs inside a
+                // stdout 'data' event handler and a synchronous throw would be an
+                // uncaught exception. Cancellation takes effect at the next
+                // stage-boundary checkpoint after downloadAsync resolves.
+                try {
+                    onProgress('yt-dlp', pct);
+                } catch {
+                    // intentionally swallowed — see comment above
+                }
             }
         },
         // yt-dlp auto-detects Deno (provisioned via the image/flake) to solve YouTube's

--- a/src/tasks/pipeline.ts
+++ b/src/tasks/pipeline.ts
@@ -15,6 +15,12 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
+/**
+ * onProgress doubles as the cancellation checkpoint: TaskManager may throw
+ * TaskCancelledError from it. Never call it synchronously from inside an
+ * EventEmitter/stream handler — a throw there is an uncaught exception.
+ * Wrap forwarded callbacks in try/catch (see downloadYTV's yt-dlp progress).
+ */
 export type Task<Args, Ret> = (args: Args, onProgress: (stage: string, progressPercent: number) => void) => Promise<Ret>;
 
 export type PipelineDeps = {

--- a/src/tasks/transcribe.ts
+++ b/src/tasks/transcribe.ts
@@ -4,6 +4,7 @@ import { CityLanguage, Transcript } from "../types.js";
 import { scribeTranscriber, MAX_TRANSCRIPTION_SEGMENT_DURATION_SECONDS } from "../lib/ScribeTranscribe.js";
 import { createScopedLogger } from "./utils/scopedLogger.js";
 import { formatTime } from "../utils.js";
+import { throwIfCancelled } from "../lib/taskControl.js";
 
 dotenv.config();
 
@@ -85,6 +86,7 @@ export const transcribe: Task<TranscribeArgs, Transcript> = async ({ segments, l
 
     const results: (Transcript & { start: number })[] = [];
     for (let i = 0; i < settled.length; i++) {
+        throwIfCancelled();
         const result = settled[i];
         results.push(result.status === "fulfilled" ? result.value : await transcribeSegment(segments[i], i));
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  */
 
 export interface TaskUpdate<T> {
-    status: "processing" | "success" | "error";
+    status: "processing" | "success" | "error" | "cancelled";
     stage: string;
     progressPercent: number;
     result?: T;


### PR DESCRIPTION
## Summary

On 2026-07-17 the `strovolos/may14_2026` summarize run took **5h17m**: its first batch-processing chunk sat in Anthropic's Message Batches queue for 4h55m during a backlog on their side (comparable sibling chunks took 5–9 minutes; the Batch API only guarantees completion within 24h). We had no way to react — the task couldn't be stopped, and its LLM calls couldn't leave the batch queue without restarting the whole run and losing all completed work.

This PR adds the two missing controls, tasks-side only:

- **Promotion** (the headline): `POST /tasks/:id/promote` switches a running task's LLM calls from the Batch API to streaming *mid-run*. The in-flight Anthropic batch is cancelled; if the request actually finished before the cancel landed, its (already-paid, batch-discounted) result is used as-is — otherwise the same request is re-issued via streaming. Every subsequent LLM call in the task skips the Batch API. The task itself never notices; no work is lost. Cost is bounded: remaining calls trade the 50% batch discount for latency, and the worst race case pays one discounted generation plus its streaming retry.
- **Cancellation** (the capability promotion is built on): `POST /tasks/:id/cancel` cooperatively cancels a running or queued task. A per-task `AbortSignal` (carried via AsyncLocalStorage, mirroring the existing `runWithTaskTrace` pattern — zero task-signature changes) is observed in the batch poll loop (the Anthropic batch is cancelled server-side too — $0 if still queued), inside in-flight SDK calls, in retry/rate-limit sleeps, and at every task's `onProgress` checkpoint. Terminal state is reported with a new `cancelled` callback status.

## API surface (what opencouncil integrates with next)

| Change | Detail |
|---|---|
| `202` on task submission | now includes `taskId` (collision-safe across restarts: `task_<hex>_<n>`) |
| `GET /tasks` | running + queued tasks with `taskId`, `stage`, `progressPercent`, `llmMode` |
| `POST /tasks/:taskId/cancel` | `{status: 'cancelling'\|'cancelled'}`; queued tasks dequeue immediately |
| `POST /tasks/:taskId/promote` | `{llmMode: 'streaming'}`; idempotent |
| Callbacks | additive `taskId` field; new terminal `status: "cancelled"` |
| CLI | `npm run cli -- tasks list \| cancel <id> \| promote <id>` (`TASKS_SERVER_URL`, `TASKS_API_TOKEN`) |

**Known limitation until the opencouncil side lands:** current opencouncil doesn't recognize `status: "cancelled"`, so a cancelled task may appear stuck in "processing" in its UI. Acceptable for now — both operations are operator-initiated via CLI/curl.

Out of scope (deliberate): automatic promotion after a wait threshold, opencouncil UI integration, and hard-killing media subprocesses (ffmpeg/yt-dlp) — media tasks cancel at stage boundaries.

## Test plan

- [x] 477 unit tests green (21 new: promote/cancel races against a fake batch client, TaskManager classification incl. mid-SDK-call aborts, queue semantics, signal primitives)
- [x] End-to-end against a local server with a dev-only canary task (`POST /dev/slowTask`, non-production only):
  - cancel mid-run → `cancelled` callback in <1s, slot freed
  - promote mid-batch → real Anthropic batch cancelled; race-lost branch observed live (paid result used); task finished `success` with `llmMode: "streaming"`
  - cancel mid-batch → Anthropic batch cancelled server-side, task reported `cancelled`
- [ ] Exercise cancel/promote against the PR preview deployment (preview imitates production, so this uses a real task rather than the canary)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds cooperative task cancellation and mid-run batch-to-streaming promotion to the task server, motivated by a real 5h17m run caused by Anthropic's Batch API backlog. The implementation is clean and self-contained: a new `TaskControl` object (cancel + promote `AbortController`s, `llmMode`) is propagated via `AsyncLocalStorage`, so all LLM poll loops, retry sleeps, and SDK calls observe it without any task-signature changes.

- **Cancellation** (`POST /tasks/:id/cancel`): aborts a per-task `AbortSignal` observed at every `onProgress` checkpoint, `abortableSleep` call, and SDK request option; queued tasks are dequeued and given a `cancelled` callback immediately; the `completion` promise now correctly resolves only after the terminal callback is delivered.
- **Promotion** (`POST /tasks/:id/promote`): flips `llmMode` to `'streaming'` and aborts a separate promote signal that wakes the batch poll loop; the in-flight Anthropic batch is cancelled server-side; if the request already completed before the cancel landed the paid result is used as-is, otherwise `BatchPromotedError` triggers a streaming re-issue; all subsequent LLM calls in the task skip the Batch API.
- **Test coverage**: 21 new unit tests exercise cancel/promote races against a fake batch client, queue semantics, and mid-SDK-call abort classification.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the core cancel and promote paths are correctly implemented and well-tested, with no data-loss or correctness issues on the critical path.
- The implementation is thorough: cancel/promote signal priority (cancel beats promote), the abortable poll loop, the queued-task completion ordering fix, and the streaming retry after BatchPromotedError all handle their edge cases correctly. The one finding — promoteTask returning a success response for an already-cancelling task — produces a momentary misleading API response but does not affect correctness; the task still finishes as cancelled with the proper callback delivered to opencouncil.
- No files require special attention; the core logic in TaskManager.ts and ai.ts is sound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/taskControl.ts | New module introducing TaskCancelledError, TaskControl (cancel+promote AbortControllers + llmMode), and abortableSleep. Design mirrors existing observability.ts pattern; the abortableSleep cleanup (removeEventListener + clearTimeout) is correct. All exported symbols are well-typed and tested. |
| src/lib/ai.ts | Adds cancel/promote integration to executeBatch and aiChat. The wakeSignal (AbortSignal.any) correctly combines cancel and promote for the poll loop, and cancel is checked before promote for priority. promoteTask-then-cancel ordering in resolvePromotedBatch handles the race correctly but cancel signal is not threaded into retrieve/results HTTP calls (noted as out-of-diff P2). BatchPromotedError → streaming retry path correctly re-uses requestOptions with the cancel signal. |
| src/lib/TaskManager.ts | Adds taskId generation (collision-safe INSTANCE_ID prefix), cancelTask, and promoteTask. completion promise for queued tasks now resolves inside sendCallback.finally() matching the running-task path (previous P1 fixed). promoteTask returns true for a cancelling (signal aborted, not yet finished) task, causing the server to respond 200 with llmMode:'streaming' even though cancel wins — a minor UX inconsistency. |
| src/server.ts | Adds /tasks/:taskId/cancel and /tasks/:taskId/promote endpoints. GET /tasks now returns full running task objects (including callbackUrl, which was already present before). devSlowTask registration is correctly guarded by NODE_ENV !== 'production'. Both new endpoints have correct 404 handling. |
| src/tasks/downloadYTV.ts | onProgress call inside the yt-dlp stdout 'data' event handler is wrapped in try/catch to swallow TaskCancelledError — intentional and documented. Cancellation is observed at the next stage-boundary call after downloadAsync resolves, consistent with the PR's stated scope. |
| src/tasks/devSlowTask.ts | New dev-only canary task for exercising cancel/promote end-to-end. Correctly uses abortableSleep + throwIfCancelled for cooperative cancellation. Registration in server.ts is gated behind NODE_ENV !== 'production'. |
| src/lib/TaskManager.test.ts | New test file with 8 cases covering cancellation, promotion, queue semantics, and SDK-abort error classification. Tests use stubCallbacks to intercept fetch and check terminal payload status. Coverage includes the mid-SDK-call abort scenario (APIUserAbortError classified as cancelled). |
| src/lib/ai.test.ts | Adds 4 executeBatch tests against a fake Anthropic client: cancel fires immediately, promote-cancel-wins (BatchPromotedError), promote-request-already-succeeded (paid result reuse), and normal completion without task control. Covers the critical race cases described in the PR. |
| src/lib/observability.ts | Distinguishes cancelled traces from error traces using the same TaskCancelledError || signal.aborted discriminator as TaskManager. Adds status:cancelled tag and task-cancelled WARNING event so cancellations are filterable in Langfuse dashboards. |
| src/cli.ts | Adds tasks list/cancel/promote sub-commands using a shared tasksServerRequest helper. The observability check correctly updated to await .completion after the return type of runTaskWithCallback changed from Promise<void> to { taskId, completion }. |
| src/types.ts | Adds 'cancelled' to TaskUpdate.status union — an additive change. opencouncil integration is acknowledged to not yet handle this status. |

<sub>Reviews (9): Last reviewed commit: ["feat(observability): tag cancelled runs ..."](https://github.com/schemalabz/opencouncil-tasks/commit/2ec4c166140803d85f7d5bede8ec172795d0cca2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45625679)</sub>

<!-- /greptile_comment -->