### PR TITLE
ci(preview): author-gated deploys, fork-checkout opt-in, cleanup eligibility

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   pull-requests: write
   issues: write
+  actions: write
 
 # Ensure only one cleanup runs at a time per PR
 concurrency:
@@ -15,10 +16,70 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Decide whether a preview was ever deployed for this PR, and cancel any
+  # deploy runs still waiting for approval. Runs without an environment so
+  # closing an undeployed PR never triggers an approval prompt.
+  check:
+    name: Check Cleanup Eligibility
+    runs-on: ubuntu-latest
+    outputs:
+      deployed: ${{ steps.check-deploy.outputs.deployed }}
+    steps:
+      - name: Check whether a preview was deployed
+        id: check-deploy
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            // The deploy job's first step (which only runs after approval)
+            // posts a comment containing "Preview deployment" — its presence
+            // means a deploy was approved and a preview may exist on the host.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes('Preview deployment')
+            );
+
+            core.setOutput('deployed', botComment ? 'true' : 'false');
+            console.log(botComment
+              ? 'Deploy comment found - preview cleanup is needed'
+              : 'No deploy comment found - skipping cleanup');
+
+      - name: Cancel deploy runs pending approval
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // A deploy run waiting for environment approval would otherwise
+            // linger in the Actions tab for 30 days after the PR closes.
+            const headSha = context.payload.pull_request.head.sha;
+
+            const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'preview-deploy.yml',
+              head_sha: headSha,
+            });
+
+            for (const run of runs.filter(run => run.status !== 'completed')) {
+              console.log(`Cancelling deploy run ${run.id} (status: ${run.status})`);
+              await github.rest.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+            }
+
   cleanup:
     name: Destroy Preview Instance
     runs-on: ubuntu-latest
-    environment: preview
+    needs: check
+    if: needs.check.outputs.deployed == 'true'
+    environment: preview-cleanup
     steps:
       - name: Cleanup preview deployment
         env:
@@ -62,7 +123,7 @@ jobs:
           echo "- Caddy configuration removed" >> $GITHUB_STEP_SUMMARY
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -18,14 +18,47 @@ env:
   CACHIX_CACHE_NAME: ${{ secrets.CACHIX_CACHE_NAME || 'opencouncil' }}
 
 jobs:
+  # Route the deploy through the right environment: PRs authored by users
+  # with write access deploy automatically via 'preview-auto', everyone
+  # else (forks, dependabot) goes through the reviewer-gated 'preview'.
+  gate:
+    name: Determine Deploy Environment
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.select.outputs.environment }}
+    steps:
+      - name: Check PR author permission
+        id: select
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              permission = data.permission;
+            } catch (error) {
+              console.log(`Could not resolve permission for ${author}: ${error.message}`);
+            }
+
+            const trusted = ['admin', 'write'].includes(permission);
+            core.setOutput('environment', trusted ? 'preview-auto' : 'preview');
+            console.log(`Author ${author} has '${permission}' permission - `
+              + (trusted ? 'deploying automatically' : 'deploy requires approval'));
+
   deploy:
     name: Build and Deploy Preview
     runs-on: ubuntu-latest
-    environment: preview
+    needs: gate
+    environment: ${{ needs.gate.outputs.environment }}
     steps:
       - name: Comment on PR (building)
         id: pr-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -68,9 +101,12 @@ jobs:
             core.setOutput('comment-id', commentId);
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Deliberate: fork code only builds after the gate job routed this run
+          # through an environment (reviewer approval for non-team authors).
+          allow-unsafe-pr-checkout: true
 
       - name: Install Nix
         uses: cachix/install-nix-action@v26
@@ -108,7 +144,7 @@ jobs:
           echo "Store path: $STORE_PATH"
 
       - name: Update PR comment (deploying)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const commentId = ${{ steps.pr-comment.outputs.comment-id }};
@@ -178,7 +214,7 @@ jobs:
           echo "Preview did not return HTTP 200 after 10 attempts"
 
       - name: Update PR comment (result)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const commentId = ${{ steps.pr-comment.outputs.comment-id }};


### PR DESCRIPTION
## Summary

Preview deploys broke for fork PRs (e.g. #73): `actions/checkout` now refuses to check out fork PR code from `pull_request_target` workflows unless explicitly opted in. opencouncil hit the same wall and fixed it in schemalabz/opencouncil#552 on top of its author-gated deploy model (opencouncil@c8ac0994, opencouncil@ce31e9b2). This PR ports that whole model here so the two repos' preview workflows stay in lockstep — the repos previously differed (opencouncil required approval for every deploy; this repo required none), and both now converge on:

- **`gate` job** routes each deploy by the PR author's repo permission: write-access authors deploy automatically through the reviewer-less `preview-auto` environment; everyone else (external forks, bots) goes through the reviewer-gated `preview` environment **on every push**, since each new push is new untrusted code.
- **`allow-unsafe-pr-checkout: true`** on the checkout step — safe because the gate's environments approve the run before any fork code is built.
- **Cleanup** runs without an approval prompt via the reviewer-less `preview-cleanup` environment, only for PRs that actually deployed (checked via the deploy bot comment), and cancels deploy runs still pending approval when a PR closes.
- Action versions aligned with opencouncil (`checkout@v6`, `github-script@v9`).

## Environments (already configured)

- `preview-auto` — no reviewers (team auto-deploy)
- `preview-cleanup` — no reviewers
- `preview` — required reviewer added

## Test plan

- [x] All three workflow YAMLs parse cleanly
- [ ] After merge: re-run the failed preview deploy on #73 — should route through `preview-auto` and deploy without approval
- [ ] First external-fork PR: verify it pauses on the `preview` environment for approval

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the author-gated preview-deploy model from `schemalabz/opencouncil` to this repo, fixing broken fork-PR deploys and aligning the two repos' CI workflows.

- **`gate` job** checks the PR author's repo permission and routes to either `preview-auto` (admin/write authors, no approval) or `preview` (everyone else, reviewer-gated on every push), then the `deploy` job uses `allow-unsafe-pr-checkout: true` safely behind that gate.
- **Cleanup** gains a `check` job (no environment, so no approval prompt) that looks for an existing deploy bot comment before running SSH teardown, and cancels any deploy runs still waiting for approval when the PR closes.
- Action versions bumped to `checkout@v6` / `github-script@v9`, `actions: write` permission added to the cleanup workflow to support run cancellation.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The security model is correct — fork code only executes after the gate environment has approved the run, and the cleanup workflow never blocks on an approval prompt for PRs that were never deployed.

The `pull_request_target` + environment gate + `allow-unsafe-pr-checkout: true` combination is the right pattern for trusted fork deploys. The one practical gap is that org collaborators holding the `maintain` role would be misrouted to the reviewer-gated path instead of auto-deploy, since the trusted list only covers `admin` and `write`.

.github/workflows/preview-deploy.yml — specifically the `gate` job's permission check if the org uses `maintain`-level collaborators.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/preview-deploy.yml | Adds a `gate` job that routes deploys through `preview-auto` (write/admin) or reviewer-gated `preview` (everyone else), and enables `allow-unsafe-pr-checkout: true` safely behind that gate. The `maintain` permission level is not included as trusted, which could affect org maintainers. |
| .github/workflows/preview-cleanup.yml | Adds a `check` job (no environment, no approval prompt) that confirms a deploy comment exists before running cleanup, and cancels any pending-approval deploy runs when the PR closes. Logic and permissions look correct. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpreview-deploy.yml%3A48-49%0A**%60maintain%60%20role%20not%20counted%20as%20trusted**%0A%0A%60getCollaboratorPermissionLevel%60%20can%20return%20%60maintain%60%20for%20org-repo%20collaborators%20who%20have%20the%20Maintainer%20role%20%28distinct%20from%20%60write%60%29.%20With%20the%20current%20check%2C%20a%20team%20maintainer%20would%20be%20routed%20through%20the%20reviewer-gated%20%60preview%60%20environment%20instead%20of%20%60preview-auto%60%2C%20requiring%20manual%20approval%20on%20every%20push%20despite%20being%20a%20trusted%20team%20member.%20If%20your%20org%20uses%20the%20%60maintain%60%20role%2C%20consider%20adding%20it%20to%20the%20trusted%20list.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20const%20trusted%20%3D%20%5B'admin'%2C%20'write'%2C%20'maintain'%5D.includes%28permission%29%3B%0A%60%60%60%0A%0A&repo=schemalabz%2Fopencouncil-tasks&pr=74&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/preview-deploy.yml:48-49
**`maintain` role not counted as trusted**

`getCollaboratorPermissionLevel` can return `maintain` for org-repo collaborators who have the Maintainer role (distinct from `write`). With the current check, a team maintainer would be routed through the reviewer-gated `preview` environment instead of `preview-auto`, requiring manual approval on every push despite being a trusted team member. If your org uses the `maintain` role, consider adding it to the trusted list.

```suggestion
            const trusted = ['admin', 'write', 'maintain'].includes(permission);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(preview): author-gated deploys, fork-..."](https://github.com/schemalabz/opencouncil-tasks/commit/4f36383c92a331c64c04055fe112322d259bc1c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45718536)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->