### PR TITLE
fix(ai): request structured outputs through the GA output_config.format

### DIFF
--- a/src/lib/ai.test.ts
+++ b/src/lib/ai.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import Anthropic from '@anthropic-ai/sdk';
-import { classifyTransientError, formatApiError, addUsage, NO_USAGE, continuationPrompt, cutToLineBoundary } from './ai.js';
+import { classifyTransientError, formatApiError, addUsage, NO_USAGE, continuationPrompt, cutToLineBoundary, structuredOutputParams } from './ai.js';
 
 // ===========================================================================
 // cutToLineBoundary — truncated partials stitch at line boundaries so the
@@ -174,5 +174,31 @@ describe('addUsage', () => {
 
         expect(leftAssoc.input_tokens).toBe(rightAssoc.input_tokens);
         expect(leftAssoc.output_tokens).toBe(rightAssoc.output_tokens);
+    });
+});
+
+// ===========================================================================
+// structuredOutputParams — structured outputs are requested through the GA
+// `output_config.format` parameter, not the deprecated top-level
+// `output_format` plus its beta header
+// ===========================================================================
+
+describe('structuredOutputParams', () => {
+
+    const format: Anthropic.Beta.Messages.BetaJSONOutputFormat = {
+        type: 'json_schema',
+        schema: { type: 'object', properties: { name: { type: 'string' } } },
+    };
+
+    it('nests the schema under output_config.format', () => {
+        expect(structuredOutputParams(format)).toEqual({ output_config: { format } });
+    });
+
+    it('does not emit the deprecated top-level output_format', () => {
+        expect(structuredOutputParams(format)).not.toHaveProperty('output_format');
+    });
+
+    it('adds nothing when no format is requested', () => {
+        expect(structuredOutputParams(undefined)).toEqual({});
     });
 });

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -82,7 +82,7 @@ type AiChatOptions = {
     parseJson?: boolean;
     maxTokens?: number;
     tools?: Anthropic.Messages.Tool[];
-    outputFormat?: Anthropic.Beta.Messages.MessageCreateParams['output_format'];
+    outputFormat?: Anthropic.Beta.Messages.BetaJSONOutputFormat;
     cacheSystemPrompt?: boolean;  // Enable prompt caching for system prompt
     batchFirst?: boolean;  // Skip streaming, go directly to Batches API (300K output limit)
     label?: string;  // Observability: generation name shown in Langfuse (defaults to "aiChat")
@@ -181,13 +181,13 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 
 const BATCH_POLL_INTERVAL_MS = 60_000; // 60s between polls
 
-async function executeBatch(requestParams: Anthropic.Messages.MessageCreateParamsNonStreaming, requestOptions: Anthropic.RequestOptions): Promise<Anthropic.Messages.Message> {
+async function executeBatch(requestParams: Anthropic.Messages.MessageCreateParamsNonStreaming): Promise<Anthropic.Messages.Message> {
     const batch = await anthropic.messages.batches.create({
         requests: [{
             custom_id: 'request-1',
             params: requestParams,
         }],
-    }, requestOptions);
+    });
 
     console.log(`Batch created: ${batch.id}, polling for result...`);
 
@@ -238,6 +238,21 @@ export function cutToLineBoundary(partial: string): string {
 export function continuationPrompt(partial: string): string {
     const tail = partial.slice(-200);
     return `Your previous response was cut off by the output token limit. It currently ends with:\n${tail}\n\nContinue EXACTLY from where it stopped: output only the remaining content, completing the line you were in the middle of if it was cut mid-line. Do not repeat anything already written, do not add any preamble or commentary, and do not restart any numbering or structure from the beginning.`;
+}
+
+/**
+ * Structured outputs went GA: the canonical request parameter is
+ * `output_config.format`, and no beta header is needed. The older top-level
+ * `output_format` plus the `structured-outputs-2025-11-13` header still works
+ * but is deprecated, so it will break whenever that path is dropped.
+ *
+ * `output_config` is not declared on the SDK's stable request type yet (the
+ * installed 0.71.2 only types it under the beta namespace, and even there
+ * without a `format` field), so this is spread into the params object to reach
+ * the wire untyped. Inline it once the SDK is bumped far enough to type it.
+ */
+export function structuredOutputParams(outputFormat?: Anthropic.Beta.Messages.BetaJSONOutputFormat) {
+    return outputFormat ? { output_config: { format: outputFormat } } : {};
 }
 
 export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystemResponse, continueFromPartial, prependToResponse, documentBase64, parseJson = true, maxTokens: maxTokensParam, tools, outputFormat, cacheSystemPrompt = false, batchFirst = false, label }: AiChatOptions): Promise<ResultWithUsage<T>> {
@@ -298,9 +313,7 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
             // Opus 4.7 rejects the temperature parameter; older models still accept it.
             ...(resolvedModel.startsWith("claude-opus-4-7") ? {} : { temperature: 0 }),
             ...(tools && { tools }),
-            ...(outputFormat && {
-                output_format: outputFormat
-            })
+            ...structuredOutputParams(outputFormat)
         };
 
         generation = observeGeneration({
@@ -315,13 +328,6 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
             metadata: { batchFirst, cacheSystemPrompt, maxTokens, hasTools: Boolean(tools), hasDocument: Boolean(documentBase64) },
         });
 
-        // Prepare request options with beta headers if needed
-        const requestOptions: Anthropic.RequestOptions = outputFormat ? {
-            headers: {
-                'anthropic-beta': 'structured-outputs-2025-11-13'
-            }
-        } : {};
-
         // Stream with retry, fall back to Batches API if all retries exhausted.
         // Streaming is fast (seconds) but fragile on long requests. The Batches API
         // is slower (minutes of queue time) but immune to connection drops.
@@ -329,17 +335,17 @@ export async function aiChat<T>({ model, systemPrompt, userPrompt, prefillSystem
         let response: Anthropic.Messages.Message;
         let usedBatch = batchFirst;
         if (batchFirst) {
-            response = await executeBatch(requestParams, requestOptions);
+            response = await executeBatch(requestParams);
         } else {
             try {
                 response = await withRetry(async () => {
-                    const stream = anthropic.messages.stream(requestParams, requestOptions);
+                    const stream = anthropic.messages.stream(requestParams);
                     return stream.finalMessage();
                 });
             } catch (e) {
                 if (classifyTransientError(e)) {
                     console.log(`Streaming failed after retries, falling back to batch mode...`);
-                    response = await executeBatch(requestParams, requestOptions);
+                    response = await executeBatch(requestParams);
                     usedBatch = true;
                 } else {
                     throw e;

--- a/src/lib/ai.wire.test.ts
+++ b/src/lib/ai.wire.test.ts
@@ -1,0 +1,89 @@
+// Wire-level check for the structured-outputs request shape.
+//
+// structuredOutputParams is unit-tested in ai.test.ts, but that only proves the
+// fragment aiChat builds. The parameter still has to survive the SDK: because
+// `output_config` is not on the SDK's stable request type, it is spread in
+// untyped and reaches the wire only as long as the SDK forwards unknown keys.
+// A quiet drop there would disable structured outputs everywhere with no type
+// error and no test failure, so assert against the bytes actually sent.
+//
+// Runs against a throwaway localhost server (the SDK honours ANTHROPIC_BASE_URL),
+// so it needs no API key. The server answers 400, which classifyTransientError
+// treats as non-transient — aiChat fails fast instead of retrying.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+
+type Captured = { headers: http.IncomingHttpHeaders; body: any };
+
+let server: http.Server;
+let captured: Captured | null = null;
+
+const SCHEMA = { type: 'object', properties: { name: { type: 'string' } } } as const;
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        let raw = '';
+        req.on('data', chunk => (raw += chunk));
+        req.on('end', () => {
+            captured = { headers: req.headers, body: JSON.parse(raw || '{}') };
+            res.writeHead(400, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({
+                type: 'error',
+                error: { type: 'invalid_request_error', message: 'wire probe' },
+            }));
+        });
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    const { port } = server.address() as import('net').AddressInfo;
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${port}`;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-wire-probe';
+});
+
+afterAll(() => new Promise<void>(resolve => server.close(() => resolve())));
+
+describe('structured-outputs request shape', () => {
+
+    it('puts the schema under output_config.format, with no beta header', async () => {
+        const { aiChat } = await import('./ai.js');
+
+        await expect(aiChat({
+            systemPrompt: 'sys',
+            userPrompt: 'usr',
+            outputFormat: { type: 'json_schema', schema: SCHEMA },
+        })).rejects.toBeTruthy();
+
+        expect(captured!.body.output_config).toEqual({
+            format: { type: 'json_schema', schema: SCHEMA },
+        });
+        // The deprecated pair: top-level parameter and the beta header that gated it.
+        expect(captured!.body.output_format).toBeUndefined();
+        expect(captured!.headers['anthropic-beta']).toBeUndefined();
+    }, 30_000);
+
+    it('carries the same params through the batch path', async () => {
+        captured = null;
+        const { aiChat } = await import('./ai.js');
+
+        await expect(aiChat({
+            systemPrompt: 'sys',
+            userPrompt: 'usr',
+            batchFirst: true,
+            outputFormat: { type: 'json_schema', schema: SCHEMA },
+        })).rejects.toBeTruthy();
+
+        expect(captured!.body.requests[0].params.output_config).toEqual({
+            format: { type: 'json_schema', schema: SCHEMA },
+        });
+        expect(captured!.headers['anthropic-beta']).toBeUndefined();
+    }, 30_000);
+
+    it('omits output_config entirely when no schema is requested', async () => {
+        captured = null;
+        const { aiChat } = await import('./ai.js');
+
+        await expect(aiChat({ systemPrompt: 'sys', userPrompt: 'usr' })).rejects.toBeTruthy();
+
+        expect(captured!.body).not.toHaveProperty('output_config');
+    }, 30_000);
+});


### PR DESCRIPTION
Closes #49.

## What and why

`aiChat` asked for structured outputs the old way: the top-level `output_format`
parameter plus the `structured-outputs-2025-11-13` beta header. Structured
outputs has since gone GA, where the parameter lives at `output_config.format`
and no beta header is needed. The docs are explicit that the old pair keeps
working for a transition period, so nothing is broken today. The reason to move
now is that every structured-output caller goes through this one function, so
pollDecisions, summarize and processAgenda would all break together on the day
that path is dropped.

## What changed

The schema moves under `output_config.format` and the beta header goes away.
That leaves `requestOptions` empty, so it drops out of `executeBatch` and the
`messages.stream` call as well. The option callers pass is still `outputFormat`,
so the change stays inside `ai.ts` and the three call sites are untouched.

The option's type now points at `BetaJSONOutputFormat` rather than at
`MessageCreateParams['output_format']`, which was a reference to the very key
being deprecated.

## About the SDK

`output_config` is not on the SDK's stable request type. The installed 0.71.2
types it only under the beta namespace, and even there without a `format` field,
so the new parameter is spread in untyped to reach the wire. That is the same
route `output_format` already took. Typing it properly means going from 0.71.2
to 0.115.x, which is a large enough jump to deserve its own PR rather than
riding along here.

## What I verified, and what I did not

`ai.test.ts` had no test touching structured outputs at all, so this adds some.
The unit tests cover the fragment being built, and because the untyped spread is
the fragile part, `ai.wire.test.ts` asserts the bytes actually sent: the schema
arrives under `output_config.format`, `output_format` is gone, and no
`anthropic-beta` header goes out, on both the streaming and the batch path. It
points the SDK at a throwaway localhost server through `ANTHROPIC_BASE_URL`, so
it needs no API key. I checked the assertions have teeth by restoring the old
shape, which fails four tests.

Full suite is 523 passing and `tsc --noEmit` is clean.

**This has not been run against the real API.** I have no key in this
environment, so what is proven is the request shape, not that Anthropic accepts
it. The shape comes from the official structured-outputs docs, which state that
`output_format` moved to `output_config.format` and that beta headers are no
longer required. Before merging, someone with a key should run one real
structured-output call, ideally `processAgenda` over a PDF since it exercises
the document path too. Happy to do it myself if I can get access to a
non-production key.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates Anthropic structured-output requests from the deprecated top-level parameter and beta header to the GA `output_config.format` request shape.
- Centralizes construction of the new structured-output request fragment in `ai.ts`.
- Removes the obsolete beta-header request options from streaming and batch calls.
- Adds unit and wire-level tests covering streaming, batch, and requests without schemas.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/ai.ts | Migrates shared structured-output handling to `output_config.format` and consistently removes the obsolete beta-header options from streaming and batch paths. |
| src/lib/ai.test.ts | Adds focused unit coverage for nesting, deprecated-key omission, and the no-format case. |
| src/lib/ai.wire.test.ts | Adds localhost wire-level checks confirming the serialized streaming and batch request shapes and absence of the beta header. |

<sub>Reviews (2): Last reviewed commit: ["test(ai): assert the structured-outputs ..."](https://github.com/schemalabz/opencouncil-tasks/commit/2ee721ebf674cde3dc9072e5fda919a488b0b41d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50488308)</sub>

**Context used:**

- Knowledge Base — [Content AI: transcript fixing, agenda extraction, and summarization](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil-tasks/-/docs/content-ai.md)

<!-- /greptile_comment -->