### PR TITLE
fix(geocode): emit subject coordinates as GeoJSON [lng, lat]

### DIFF
--- a/src/lib/subjectEnrichment.test.ts
+++ b/src/lib/subjectEnrichment.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./geocode.js");
+vi.mock("./claudeSearch.js");
+
+import { enrichSubjectData, type EnrichmentInput } from "./subjectEnrichment.js";
+import { geocodeLocation } from "./geocode.js";
+import { getSubjectContextWithClaude } from "./claudeSearch.js";
+
+const mockedGeocode = vi.mocked(geocodeLocation);
+const mockedContext = vi.mocked(getSubjectContextWithClaude);
+
+function input(overrides: Partial<EnrichmentInput> = {}): EnrichmentInput {
+    return {
+        name: "Ανάπλαση πλατείας",
+        description: "…",
+        locationText: "Πλατεία Συντάγματος",
+        topicImportance: "normal",
+        proximityImportance: "near",
+        topicLabel: null,
+        agendaItemIndex: 1,
+        introducedByPersonId: null,
+        speakerContributions: [],
+        discussedIn: null,
+        ...overrides,
+    };
+}
+
+describe("enrichSubjectData", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockedContext.mockResolvedValue({ result: { text: "", citationUrls: [] } } as any);
+    });
+
+    it("emits coordinates in GeoJSON [lng, lat] order", async () => {
+        // Athens: lat 37.98 (north), lng 23.73 (east). Emitting [lat, lng]
+        // instead lands the pin near Cairo once read as [lng, lat].
+        mockedGeocode.mockResolvedValue({ lat: 37.9838, lng: 23.7275 });
+
+        const { result } = await enrichSubjectData(input(), "abc123", {
+            cityName: "Αθήνα",
+            country: "GR",
+            date: "2026-01-01",
+        });
+
+        expect(result.location).toEqual({
+            text: "Πλατεία Συντάγματος",
+            type: "point",
+            coordinates: [[23.7275, 37.9838]],
+        });
+    });
+
+    it("leaves location null when geocoding fails", async () => {
+        mockedGeocode.mockResolvedValue(null);
+
+        const { result } = await enrichSubjectData(input(), "abc123", {
+            cityName: "Αθήνα",
+            date: "2026-01-01",
+        });
+
+        expect(result.location).toBeNull();
+    });
+
+    it("does not geocode when there is no location text", async () => {
+        const { result } = await enrichSubjectData(input({ locationText: null }), "abc123", {
+            cityName: "Αθήνα",
+            date: "2026-01-01",
+        });
+
+        expect(mockedGeocode).not.toHaveBeenCalled();
+        expect(result.location).toBeNull();
+    });
+});

--- a/src/lib/subjectEnrichment.ts
+++ b/src/lib/subjectEnrichment.ts
@@ -57,7 +57,9 @@ export async function enrichSubjectData(
             location = {
                 text: input.locationText,
                 type: "point" as const,
-                coordinates: [[locationLatLng.lat, locationLatLng.lng]]
+                // GeoJSON order: [lng, lat]. The consumer feeds this straight
+                // into ST_GeomFromGeoJSON, which reads position[0] as longitude.
+                coordinates: [[locationLatLng.lng, locationLatLng.lat]]
             };
         }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -141,7 +141,8 @@ app.post('/transcribe', (
 app.post('/summarize', taskManager.registerTask(summarize, {
     summary: 'Summarize transcript content',
     description: 'Generate a summary of transcript content with subject extraction',
-    version: 5,
+    // v6: subject location coordinates are emitted as GeoJSON [lng, lat] (were [lat, lng])
+    version: 6,
   }));
 
 app.post('/splitMediaFile', taskManager.registerTask(splitMediaFile, {
@@ -158,7 +159,8 @@ app.post('/fixTranscript', taskManager.registerTask(fixTranscript, {
 app.post('/processAgenda', taskManager.registerTask(processAgenda, {
   summary: 'Process meeting agenda',
   description: 'Extracts and structures agenda information from documents',
-  version: 3,
+  // v4: subject location coordinates are emitted as GeoJSON [lng, lat] (were [lat, lng])
+  version: 4,
 }));
 
 app.post('/generateVoiceprint', taskManager.registerTask(generateVoiceprint, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,10 @@ export interface DiscussionRange {
 export interface Location {
     type: "point" | "lineString" | "polygon";
     text: string; // e.g. an area, an address, a road name
-    coordinates: number[][]; // a sequence of coordinates. just one coordinate for a point, more for a line or polygon
+    // A sequence of GeoJSON positions — just one for a point, more for a line or polygon.
+    // Each position is [longitude, latitude], per RFC 7946; consumers pass these
+    // to ST_GeomFromGeoJSON, which reads them in that order.
+    coordinates: number[][];
 }
 
 export interface Subject {


### PR DESCRIPTION
Subject location coordinates are emitted as `[lat, lng]`. The opencouncil web app feeds that array straight into `ST_GeomFromGeoJSON`, which reads it as `[lng, lat]` per RFC 7946, so every subject pin is stored reversed. This is invisible in Greece (readers compensated with a Greek bounding-box hack) but puts French pins in the Indian Ocean and Serbian pins in Saudi Arabia.

## The fix

`src/lib/subjectEnrichment.ts` now emits `[lng, lat]`, and `Location.coordinates` in `src/types.ts` documents the GeoJSON order so it doesn't regress.

## Other code paths

- **Emitters:** `subjectEnrichment.ts` is the only one. Both enrichment entry points — `summarize.ts` and `processAgenda.ts` — go through `enrichSubjectData`, so one fix covers both tasks. A repo-wide grep for `coordinates` hits only `types.ts`, `subjectEnrichment.ts`, and a geocode test.
- **Inbound coordinates are unused — confirmed, not assumed.** `SummarizeRequest.existingSubjects` is typed `Subject[]`, so the web app does send `location.coordinates`. But `compression.ts` reduces each existing subject to `locationText: subj.location?.text || null` and drops the rest, and `initializeSubjectsFromExisting` carries only `locationText` forward. The array never reaches the LLM and is never echoed back — every emitted subject's coordinates come from a fresh geocode of `locationText`. Nothing to correct on the read side.
- **`geocodeLocation`** returns a `{lat, lng}` object, not a positional array, so it has no ordering to get wrong.
- No compensating heuristics live in this repo; those are all web-app side.

## Also

- Task versions bumped: summarize 5→6, processAgenda 3→4, so consumers can tell results written before and after the flip apart.
- New `src/lib/subjectEnrichment.test.ts` pins the emitted order (Athens → `[23.7275, 37.9838]`) plus the null-geocode and no-location-text paths.

## Coordination

schemalabz/opencouncil#626 flips the stored coordinates with a migration and deletes the compensating heuristics. **It ships first.** Until this deploys, any subject the summarize pipeline writes lands reversed again, so the two need to go out close together.

## Verification

`npm run typecheck` clean; 524 tests pass. Three failures in `src/tasks/utils/spacesUrl.test.ts` are pre-existing and unrelated — they fail identically on clean `main` (they assert behavior when `DO_SPACES_*` is unconfigured, and a local `.env` sets it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geospatial output for all newly enriched subjects; must deploy in coordination with the opencouncil migration that corrects stored data and removes client-side heuristics.
> 
> **Overview**
> **Subject map pins were stored with latitude and longitude swapped** because enrichment emitted `[lat, lng]` while the web app passes coordinates to `ST_GeomFromGeoJSON` as RFC 7946 `[lng, lat]`.
> 
> `enrichSubjectData` in `subjectEnrichment.ts` now builds point coordinates as **`[lng, lat]`**, and `Location` in `types.ts` documents that order so it does not regress. **Summarize** and **processAgenda** task versions are bumped (6 and 4) so consumers can distinguish output before and after the fix.
> 
> New **`subjectEnrichment.test.ts`** asserts Athens emits `[[23.7275, 37.9838]]`, plus null location when geocoding fails or `locationText` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa681eaaa044f6739fe214d4d8739dd6582d479f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects subject-location output to use the GeoJSON `[longitude, latitude]` convention and marks the resulting task contract versions.
- Reverses the coordinate tuple emitted by shared subject enrichment.
- Documents the GeoJSON coordinate order in the central `Location` type.
- Adds tests for successful, failed, and skipped geocoding.
- Bumps the summarize and process-agenda task versions for downstream compatibility.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge after the documented downstream migration is deployed as coordinated.

The shared enrichment path now emits the standards-compliant coordinate order, inbound coordinates cannot be echoed through that path, both affected task versions are updated, and focused tests cover the changed behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/subjectEnrichment.ts | Correctly changes the sole coordinate emitter from `[lat, lng]` to GeoJSON `[lng, lat]`. |
| src/lib/subjectEnrichment.test.ts | Adds focused coverage for coordinate ordering and both null-location paths. |
| src/server.ts | Bumps both task versions affected by the shared enrichment output contract. |
| src/types.ts | Documents the positional coordinate contract consistently with GeoJSON and the corrected emitter. |

<sub>Reviews (1): Last reviewed commit: ["fix(geocode): emit subject coordinates a..."](https://github.com/schemalabz/opencouncil-tasks/commit/fa681eaaa044f6739fe214d4d8739dd6582d479f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53338450)</sub>

**Context used:**

- Knowledge Base — [Content AI: transcript fixing, agenda extraction, and summarization](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil-tasks/-/docs/content-ai.md)
- Knowledge Base — [Server and Task API](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil-tasks/-/docs/server-and-task-api.md)

<!-- /greptile_comment -->